### PR TITLE
Feature/118 candidate users and group changes

### DIFF
--- a/view/simple/src/main/kotlin/io/holunda/camunda/taskpool/view/simple/service/TaskPoolService.kt
+++ b/view/simple/src/main/kotlin/io/holunda/camunda/taskpool/view/simple/service/TaskPoolService.kt
@@ -157,6 +157,23 @@ open class TaskPoolService(
     }
   }
 
+  @EventHandler
+  open fun on(event: TaskCandidateGroupChanged) {
+    logger.debug { "Task candidate groups changed $event received" }
+    if (tasks.containsKey(event.id)) {
+      tasks[event.id] = task(event, tasks[event.id]!!)
+      updateTaskForUserQuery(event.id)
+    }
+  }
+
+  @EventHandler
+  open fun on(event: TaskCandidateUserChanged) {
+    logger.debug { "Task user groups changed $event received" }
+    if (tasks.containsKey(event.id)) {
+      tasks[event.id] = task(event, tasks[event.id]!!)
+      updateTaskForUserQuery(event.id)
+    }
+  }
 
   @EventHandler
   open fun on(event: DataEntryCreatedEvent) {

--- a/view/simple/src/test/kotlin/io/holunda/camunda/taskpool/view/simple/service/TaskPoolStages.kt
+++ b/view/simple/src/test/kotlin/io/holunda/camunda/taskpool/view/simple/service/TaskPoolStages.kt
@@ -6,10 +6,7 @@ import com.tngtech.jgiven.annotation.BeforeScenario
 import com.tngtech.jgiven.annotation.ExpectedScenarioState
 import com.tngtech.jgiven.annotation.ProvidedScenarioState
 import com.tngtech.jgiven.annotation.ScenarioState
-import io.holunda.camunda.taskpool.api.task.ProcessReference
-import io.holunda.camunda.taskpool.api.task.TaskAssignedEngineEvent
-import io.holunda.camunda.taskpool.api.task.TaskAttributeUpdatedEngineEvent
-import io.holunda.camunda.taskpool.api.task.TaskCreatedEngineEvent
+import io.holunda.camunda.taskpool.api.task.*
 import io.holunda.camunda.taskpool.view.Task
 import io.holunda.camunda.taskpool.view.TaskWithDataEntries
 import io.holunda.camunda.taskpool.view.auth.User
@@ -42,6 +39,16 @@ open class TaskPoolStage<SELF : TaskPoolStage<SELF>> : Stage<SELF>() {
   }
 
   open fun task_attributes_update_event_is_received(event: TaskAttributeUpdatedEngineEvent): SELF {
+    testee.on(event)
+    return self()
+  }
+
+  open fun task_candidate_group_changed_event_is_received(event: TaskCandidateGroupChanged): SELF {
+    testee.on(event)
+    return self()
+  }
+
+  open fun task_candidate_user_changed_event_is_received(event: TaskCandidateUserChanged): SELF {
     testee.on(event)
     return self()
   }
@@ -116,6 +123,16 @@ open class TaskPoolThenStage<SELF : TaskPoolThenStage<SELF>> : TaskPoolStage<SEL
   @As("task with id $ is assigned to $")
   open fun task_is_assigned_to(taskId: String, assignee: String?): SELF {
     assertThat(testee.query(TaskForIdQuery(taskId))?.assignee).isEqualTo(assignee)
+    return self()
+  }
+
+  open fun task_has_candidate_groups(taskId: String, groupIds: Set<String>): SELF {
+    assertThat(testee.query(TaskForIdQuery(taskId))?.candidateGroups).isEqualTo(groupIds)
+    return self()
+  }
+
+  open fun task_has_candidate_users(taskId: String, groupIds: Set<String>): SELF {
+    assertThat(testee.query(TaskForIdQuery(taskId))?.candidateUsers).isEqualTo(groupIds)
     return self()
   }
 

--- a/view/view-api/src/main/kotlin/Task.kt
+++ b/view/view-api/src/main/kotlin/Task.kt
@@ -93,3 +93,57 @@ fun task(event: TaskAttributeUpdatedEngineEvent, task: Task) = Task(
   followUpDate = event.followUpDate,
   dueDate = event.dueDate
 )
+
+fun task(event: TaskCandidateGroupChanged, task: Task) = Task(
+  id = event.id,
+  sourceReference = event.sourceReference,
+  taskDefinitionKey = event.taskDefinitionKey,
+
+  correlations = task.correlations,
+  payload = task.payload,
+  businessKey = task.businessKey,
+  formKey = task.formKey,
+  createTime = task.createTime,
+  assignee = task.assignee,
+
+  candidateGroups = when (event.assignmentUpdateType) {
+    CamundaTaskEvent.CANDIDATE_GROUP_ADD -> task.candidateGroups.plus(event.groupId)
+    CamundaTaskEvent.CANDIDATE_GROUP_DELETE -> task.candidateGroups.minus(event.groupId)
+    else -> task.candidateGroups
+  },
+  candidateUsers = task.candidateUsers,
+
+  name = task.name,
+  description = task.description,
+  priority = task.priority,
+  owner = task.owner,
+  followUpDate = task.followUpDate,
+  dueDate = task.dueDate
+)
+
+fun task(event: TaskCandidateUserChanged, task: Task) = Task(
+  id = event.id,
+  sourceReference = event.sourceReference,
+  taskDefinitionKey = event.taskDefinitionKey,
+
+  correlations = task.correlations,
+  payload = task.payload,
+  businessKey = task.businessKey,
+  formKey = task.formKey,
+  createTime = task.createTime,
+  assignee = task.assignee,
+
+  candidateGroups = task.candidateGroups,
+  candidateUsers = when (event.assignmentUpdateType) {
+    CamundaTaskEvent.CANDIDATE_USER_ADD -> task.candidateUsers.plus(event.userId)
+    CamundaTaskEvent.CANDIDATE_USER_DELETE -> task.candidateUsers.minus(event.userId)
+    else -> task.candidateUsers
+  },
+
+  name = task.name,
+  description = task.description,
+  priority = task.priority,
+  owner = task.owner,
+  followUpDate = task.followUpDate,
+  dueDate = task.dueDate
+)


### PR DESCRIPTION
Ich habe mal schnell die Behandlung der TaskCandidateGroupChanged und TaskCandidateUserChanged events in der Simple View eingebaut, nachdem ich festgestellt hatte, dass das Änderung der Candidate Groups im Camunda Cockpit keine Auswirkungen auf das Query Result gegen die Simple View hatte.

Das programmatische Ändern der Candidate Users / Groups (Erweiterung der Taskpool API um entsprechende Interaction Commands) ist nicht enthalten, das folgt später sobald der Bedarf da ist.

Die Test-Klasse TaskPoolServiceTest.kt habe ich dahin gehend umgebaut dass man dieselben Testdaten (Task-Properties) nicht an diversen verschieden Stellen wiederholt angeben muss.