### PR TITLE
Bugfix/148 process definition

### DIFF
--- a/engine/taskpool-collector/src/main/kotlin/io/holunda/camunda/taskpool/CamundaKotlinExtensions.kt
+++ b/engine/taskpool-collector/src/main/kotlin/io/holunda/camunda/taskpool/CamundaKotlinExtensions.kt
@@ -1,6 +1,10 @@
 package io.holunda.camunda.taskpool
 
 import org.camunda.bpm.engine.RepositoryService
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl
+import org.camunda.bpm.engine.impl.interceptor.Command
+import org.camunda.bpm.engine.impl.persistence.entity.IdentityLinkEntity
+import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity
 
 fun extractKey(processDefinitionId: String?): String {
   if (processDefinitionId == null) {
@@ -24,3 +28,21 @@ fun loadCaseName(caseDefinitionId: String, repositoryService: RepositoryService)
     ?: throw IllegalArgumentException("Case definition could not be resolved for id $caseDefinitionId")
   return caseDefinition.name
 }
+
+/**
+ * Runs a command in command context.
+ */
+fun <T> ProcessEngineConfigurationImpl.executeInCommandContext(command: Command<T>): T {
+  return this.commandExecutorTxRequired.execute(command)
+}
+
+fun ProcessDefinitionEntity.candidateLinks(): List<IdentityLinkEntity> = this.identityLinks.filter { it.type == "candidate" }
+/**
+ * Retrieves a set of candidate user ids allowed to start given process definition.
+ */
+fun ProcessDefinitionEntity.candidateUsers() = this.candidateLinks().filter { it.isUser }.map { it.userId }.toSet()
+/**
+ * Retrieves a set of candidate group ids allowed to start given process definition.
+ */
+fun ProcessDefinitionEntity.candidateGroups() = this.candidateLinks().filter { it.isGroup }.map { it.groupId }.toSet()
+

--- a/engine/taskpool-collector/src/main/kotlin/io/holunda/camunda/taskpool/process/ProcessDefinitionService.kt
+++ b/engine/taskpool-collector/src/main/kotlin/io/holunda/camunda/taskpool/process/ProcessDefinitionService.kt
@@ -37,7 +37,7 @@ class ProcessDefinitionService(
   ): List<RegisterProcessDefinitionCommand> {
 
     require(Context.getCommandContext() != null) { "This method must be executed inside a Camunda command context." }
-    
+
     val query = repositoryService.createProcessDefinitionQuery()
     if (processDefinitionKey != null && processDefinitionKey.isNotBlank()) {
       query.processDefinitionKey(processDefinitionKey)

--- a/engine/taskpool-collector/src/main/kotlin/io/holunda/camunda/taskpool/process/ProcessDefinitionService.kt
+++ b/engine/taskpool-collector/src/main/kotlin/io/holunda/camunda/taskpool/process/ProcessDefinitionService.kt
@@ -2,8 +2,14 @@ package io.holunda.camunda.taskpool.process
 
 import io.holunda.camunda.taskpool.TaskCollectorProperties
 import io.holunda.camunda.taskpool.api.task.RegisterProcessDefinitionCommand
+import io.holunda.camunda.taskpool.candidateGroups
+import io.holunda.camunda.taskpool.candidateUsers
+import io.holunda.camunda.taskpool.executeInCommandContext
 import org.camunda.bpm.engine.FormService
 import org.camunda.bpm.engine.RepositoryService
+import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl
+import org.camunda.bpm.engine.impl.context.Context
+import org.camunda.bpm.engine.impl.interceptor.Command
 import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity
 import org.camunda.bpm.engine.repository.ProcessDefinition
 import org.springframework.stereotype.Component
@@ -13,35 +19,83 @@ class ProcessDefinitionService(
   private val properties: TaskCollectorProperties
 ) {
 
-  private val processDefinitions: MutableList<ProcessDefinition> = mutableListOf()
+  private val processDefinitions: MutableSet<ProcessDefinition> = mutableSetOf()
 
-  fun getProcessDefinitions(formService: FormService, repositoryService: RepositoryService, processDefinitionKey: String = "", returnAll: Boolean = true): List<RegisterProcessDefinitionCommand> {
 
+  /**
+   * Retrieves the list of process definition commands, carrying information about start forms and auth information
+   * about potential starters.
+   *
+   * This method must be called in a Camunda command context (eg. from Job or Command).
+   * @see {ProcessDefinitionService.getProcessDefinitions(ProcessEngineConfigurationImpl, String, Boolean)}
+   */
+  fun getProcessDefinitions(
+    formService: FormService,
+    repositoryService: RepositoryService,
+    processDefinitionKey: String? = null,
+    returnAll: Boolean = true
+  ): List<RegisterProcessDefinitionCommand> {
+
+    require(Context.getCommandContext() != null) { "This method must be executed inside a Camunda command context." }
+    
     val query = repositoryService.createProcessDefinitionQuery()
-    if (processDefinitionKey.isNotBlank()) {
+    if (processDefinitionKey != null && processDefinitionKey.isNotBlank()) {
       query.processDefinitionKey(processDefinitionKey)
     }
     val newDefinitions: List<ProcessDefinitionEntity> = query.list()
       .filter { returnAll || !processDefinitions.map { def -> def.id }.contains(it.id) }
       .filter { it is ProcessDefinitionEntity }
       .map { it as ProcessDefinitionEntity }
+
+    if (returnAll) {
+      this.processDefinitions.clear()
+    }
     this.processDefinitions.addAll(newDefinitions)
-    return newDefinitions.map { createCommand(it, formService.getStartFormKey(it.id)) }
+
+    return newDefinitions.map { it.asCommand(applicationName = properties.enricher.applicationName, formKey = formService.getStartFormKey(it.id)) }
+  }
+
+  /**
+   * Retrieves the list of process definition commands, carrying information about start forms and auth information
+   * about potential starters.
+   *
+   * Runs the query in a new command context, created by this method.
+   */
+  fun getProcessDefinitions(
+    cfg: ProcessEngineConfigurationImpl,
+    processDefinitionKey: String? = null,
+    returnAll: Boolean = true
+  ): List<RegisterProcessDefinitionCommand> {
+    return cfg.executeInCommandContext(Command {
+      RegisterProcessDefinitionCommandList(
+        getProcessDefinitions(
+          formService = cfg.formService,
+          repositoryService = cfg.repositoryService,
+          processDefinitionKey = processDefinitionKey,
+          returnAll = returnAll)
+      )
+    }).commands
   }
 
 
-  private fun createCommand(processDefinition: ProcessDefinitionEntity, formKey: String?) =
+  private fun ProcessDefinitionEntity.asCommand(applicationName: String, formKey: String?) =
     RegisterProcessDefinitionCommand(
-      processDefinitionId = processDefinition.id,
-      processDefinitionKey = processDefinition.key,
-      processDefinitionVersion = processDefinition.version,
-      processName = processDefinition.name,
-      processVersionTag = processDefinition.versionTag,
-      processDescription = processDefinition.description,
-      applicationName = properties.enricher.applicationName,
-      startableFromTasklist = processDefinition.isStartableInTasklist,
+      processDefinitionId = this.id,
+      processDefinitionKey = this.key,
+      processDefinitionVersion = this.version,
+      processName = this.name,
+      processVersionTag = this.versionTag,
+      processDescription = this.description,
+      startableFromTasklist = this.isStartableInTasklist,
+      applicationName = applicationName,
       formKey = formKey,
-      candidateStarterUsers = processDefinition.identityLinks.filter { it.isUser && it.type == "candidate" }.map { it.userId }.toSet(),
-      candidateStarterGroups = processDefinition.identityLinks.filter { it.isGroup && it.type == "candidate" }.map { it.groupId }.toSet()
+      candidateStarterUsers = this.candidateUsers(),
+      candidateStarterGroups = this.candidateGroups()
     )
+
+  /**
+   * Result encapsulated in a type to avoid type erasure.
+   */
+  private data class RegisterProcessDefinitionCommandList(val commands: List<RegisterProcessDefinitionCommand>)
 }
+

--- a/engine/taskpool-collector/src/main/kotlin/io/holunda/camunda/taskpool/process/RegisterProcessDefinitionParseListener.kt
+++ b/engine/taskpool-collector/src/main/kotlin/io/holunda/camunda/taskpool/process/RegisterProcessDefinitionParseListener.kt
@@ -1,5 +1,6 @@
 package io.holunda.camunda.taskpool.process
 
+import io.holunda.camunda.taskpool.executeInCommandContext
 import org.camunda.bpm.engine.impl.bpmn.parser.AbstractBpmnParseListener
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl
 import org.camunda.bpm.engine.impl.persistence.entity.ProcessDefinitionEntity
@@ -12,6 +13,6 @@ class RegisterProcessDefinitionParseListener(
   override fun parseProcess(processElement: Element, processDefinition: ProcessDefinitionEntity) {
     // create job / send command to job executor
     // to handle this deployment asynchronous.
-    processEngineConfiguration.commandExecutorTxRequired.execute(RefreshProcessDefinitionsJobCommand(processDefinitionKey = processDefinition.key))
+    processEngineConfiguration.executeInCommandContext(RefreshProcessDefinitionsJobCommand(processDefinitionKey = processDefinition.key))
   }
 }

--- a/engine/taskpool-collector/src/test/kotlin/io/holunda/camunda/taskpool/itest/ProcessDefinitionServiceITest.kt
+++ b/engine/taskpool-collector/src/test/kotlin/io/holunda/camunda/taskpool/itest/ProcessDefinitionServiceITest.kt
@@ -1,0 +1,71 @@
+package io.holunda.camunda.taskpool.itest
+
+import io.holunda.camunda.taskpool.process.ProcessDefinitionService
+import io.holunda.camunda.taskpool.sender.gateway.AxonCommandListGateway
+import org.assertj.core.api.Assertions.assertThat
+import org.camunda.bpm.engine.FormService
+import org.camunda.bpm.engine.RepositoryService
+import org.camunda.bpm.model.bpmn.Bpmn
+import org.camunda.bpm.model.xml.instance.ModelElementInstance
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit4.SpringRunner
+
+
+/**
+ * This ITests simulates work of Camunda process definition collector.
+ */
+@RunWith(SpringRunner::class)
+@SpringBootTest(classes = [TaskCollectorTestApplication::class], webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles("collector-itest")
+@DirtiesContext
+class ProcessDefinitionServiceITest {
+
+  companion object {
+    const val NS_CAMUNDA = "http://camunda.org/schema/1.0/bpmn"
+  }
+
+
+  @MockBean
+  lateinit var commandGateway: AxonCommandListGateway
+
+  @Autowired
+  private lateinit var processDefinitionService: ProcessDefinitionService
+
+  @Autowired
+  private lateinit var repositoryService: RepositoryService
+
+  @Autowired
+  private lateinit var formService: FormService
+
+  @Test
+  fun `should deliver process starter`() {
+
+    val processId = "my-id"
+    val startEventId = "start"
+    val modelInstance = Bpmn
+      .createExecutableProcess(processId)
+      .startEvent(startEventId)
+      .endEvent("end")
+      .done().apply {
+        getModelElementById<ModelElementInstance>(processId).setAttributeValue("name", "My Process")
+        getModelElementById<ModelElementInstance>(processId).setAttributeValueNs(NS_CAMUNDA, "candidateStarterGroups", "muppetshow")
+        getModelElementById<ModelElementInstance>(startEventId).setAttributeValueNs(NS_CAMUNDA, "formKey", "start-approval")
+      }
+
+    repositoryService
+      .createDeployment()
+      .addModelInstance("process-with-start-form.bpmn", modelInstance)
+      .deploy()
+
+    val definitions = processDefinitionService.getProcessDefinitions(formService, repositoryService)
+
+    assertThat(definitions).isNotEmpty
+  }
+
+}

--- a/engine/taskpool-collector/src/test/kotlin/io/holunda/camunda/taskpool/itest/ProcessDefinitionServiceITest.kt
+++ b/engine/taskpool-collector/src/test/kotlin/io/holunda/camunda/taskpool/itest/ProcessDefinitionServiceITest.kt
@@ -82,6 +82,11 @@ class ProcessDefinitionServiceITest {
     val definitions = processDefinitionService.getProcessDefinitions(configuration)
 
     assertThat(definitions).isNotEmpty
+    assertThat(definitions[0].processName).isEqualTo("My Process")
+    assertThat(definitions[0].processDefinitionKey).isEqualTo("my-id")
+    assertThat(definitions[0].processDefinitionVersion).isEqualTo(1)
+    assertThat(definitions[0].formKey).isEqualTo("start-approval")
+    assertThat(definitions[0].candidateStarterGroups).containsExactlyElementsOf(listOf("muppetshow"))
   }
 
 }

--- a/engine/taskpool-collector/src/test/kotlin/io/holunda/camunda/taskpool/itest/ProcessDefinitionServiceITest.kt
+++ b/engine/taskpool-collector/src/test/kotlin/io/holunda/camunda/taskpool/itest/ProcessDefinitionServiceITest.kt
@@ -4,7 +4,6 @@ import io.holunda.camunda.taskpool.process.ProcessDefinitionService
 import io.holunda.camunda.taskpool.sender.gateway.AxonCommandListGateway
 import org.assertj.core.api.Assertions.assertThat
 import org.camunda.bpm.engine.FormService
-import org.camunda.bpm.engine.IdentityService
 import org.camunda.bpm.engine.RepositoryService
 import org.camunda.bpm.engine.impl.cfg.ProcessEngineConfigurationImpl
 import org.camunda.bpm.model.bpmn.Bpmn
@@ -13,7 +12,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
-import org.mockito.junit.MockitoJUnit
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -59,7 +57,7 @@ class ProcessDefinitionServiceITest {
     processDefinitionService.getProcessDefinitions(formService, repositoryService)
   }
 
-    @Test
+  @Test
   fun `should deliver process starter`() {
 
     val processId = "my-id"

--- a/engine/taskpool-collector/src/test/kotlin/io/holunda/camunda/taskpool/itest/TaskCollectorITest.kt
+++ b/engine/taskpool-collector/src/test/kotlin/io/holunda/camunda/taskpool/itest/TaskCollectorITest.kt
@@ -54,7 +54,6 @@ class TaskCollectorITest {
   @Autowired
   lateinit var taskService: TaskService
 
-
   /**
    * The process is started and waits in the user task. If the instance is deleted,
    * and the listeners are notified, the delete command is sent out with process


### PR DESCRIPTION
I did two things for the fix.

- the original method now checks if it is executed in a Command context, so it rejects to be run outside.
- the second convenience method is now supplied to be able to run it inside the Command context.
- I implemented an ITest too, to check this.