### PR TITLE
chore: bump axon version also for mongo extension

### DIFF
--- a/view/mongo/pom.xml
+++ b/view/mongo/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>org.axonframework.extensions.mongo</groupId>
       <artifactId>axon-mongo</artifactId>
-      <version>4.0.1</version>
+      <version>${axon.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Version for mongo extension was explicitly specified but 4.2 is also available.