### PR TITLE
support common process variable filter for all process definitions

### DIFF
--- a/docs/src/orchid/resources/wiki/user-guide/components/engine-taskpool-collector.ad
+++ b/docs/src/orchid/resources/wiki/user-guide/components/engine-taskpool-collector.ad
@@ -118,18 +118,23 @@ In particular cases, the task related data is not sufficient for the information
 other user-related components. The information may be available as process variables and need to be attached
 to the task in the taskpool. This is where _Process Variable Task Enricher_ can be used. For this purpose,
 set the property `camunda.taskpool.collector.enricher.type` to `process-variables` and the enricher will
-put all process variables into the task payload (defaults to a empty `EXCLUDE` filter).
+put all process variables into the task payload (defaults to an empty `EXCLUDE` filter).
 
 You can control what variables will be put into task command payload by providing the Process Variables Filter.
-The `ProcessVariablesFilter` is a Spring bean holding a list individual `ProcessVariableFilter` - one per
-process definition key.
+The `ProcessVariablesFilter` is a Spring bean holding a list of individual `VariableFilter` - at most one per
+process definition key and optionally one without process definition key (a global filter).
 
-A `ProcessVariableFilter` can be of the following type:
+A `VariableFilter` can be of the following type:
 
-* `INCLUDE`: task-level include filter, denoting a list of variables to be added for task.
-* `EXCLUDE`: task-level exclude filter, denoting a list of variables to be ignored. All other variables are included.
-* `PROCESS_INCLUDE`: process-level include filter, denoting a list of variables to be added for all tasks.
-* `PROCESS_EXCLUDE`: process-level exclude filter, denoting a list of variables to be ignored for all tasks.
+* `TaskVariableFilter`:
+** `INCLUDE`: task-level include filter, denoting a list of variables to be added for the task.
+** `EXCLUDE`: task-level exclude filter, denoting a list of variables to be ignored. All other variables are included.
+* `ProcessVariableFilter` with process definition key:
+** `INCLUDE`: process-level include filter, denoting a list of variables to be added for all tasks of the process.
+** `EXCLUDE`: process-level exclude filter, denoting a list of variables to be ignored for all tasks of the process.
+* `ProcessVariableFilter` _without_ process definition key:
+** `INCLUDE`: global include filter, denoting a list of variables to be added for all tasks of all processes for which no dedicated `ProcessVariableFilter` is defined.
+** `EXCLUDE`: global exclude filter, denoting a list of variables to be ignored for all tasks of all processes for which no dedicated `ProcessVariableFilter` is defined.
 
 Here is an example, how the process variable filter can configure the enrichment:
 
@@ -142,15 +147,16 @@ Here is an example, how the process variable filter can configure the enrichment
     public ProcessVariablesFilter myProcessVariablesFilter() {
 
       return new ProcessVariablesFilter(
-        // define a applyFilter for every process
-        new ProcessVariableFilter[]{
-          // for every process definition
-          new ProcessVariableFilter(
+        // define a variable filter for every process
+        new VariableFilter[]{
+          // define for every process definition
+          // either a TaskVariableFilter or ProcessVariableFilter
+          new TaskVariableFilter(
             ProcessApproveRequest.KEY,
             // filter type
             FilterType.INCLUDE,
             ImmutableMap.<String, List<String>>builder()
-              // define a applyFilter for every task
+              // define a variable filter for every task of the process
               .put(ProcessApproveRequest.Elements.APPROVE_REQUEST, Lists.newArrayList(
                 ProcessApproveRequest.Variables.REQUEST_ID,
                 ProcessApproveRequest.Variables.ORIGINATOR)
@@ -160,10 +166,13 @@ Here is an example, how the process variable filter can configure the enrichment
                 ProcessApproveRequest.Variables.REQUEST_ID,
                 ProcessApproveRequest.Variables.COMMENT,
                 ProcessApproveRequest.Variables.APPLICANT)
-              ).build(),
-            Collections.emptyList()
-          )
-        }, Collections.emptyMap()
+              ).build()
+          ),
+          // optionally add a global filter for all processes
+          // for that no individual filter was created
+          new ProcessVariableFilter(FilterType.INCLUDE,
+            Lists.newArrayList(CommonProcessVariables.CUSTOMER_ID))
+        }
       );
     }
 

--- a/engine/taskpool-collector/src/main/kotlin/io/holunda/camunda/taskpool/enricher/ProcessVariablesTaskCommandEnricherFilter.kt
+++ b/engine/taskpool-collector/src/main/kotlin/io/holunda/camunda/taskpool/enricher/ProcessVariablesTaskCommandEnricherFilter.kt
@@ -16,7 +16,7 @@ class ProcessVariablesFilter(
 
   fun filterVariables(processDefinitionKey: ProcessDefinitionKey, taskDefinitionKey: TaskDefinitionKey, variables: VariableMap): VariableMap {
     val variableFilter = processSpecificFilters[processDefinitionKey] ?: commonFilter ?: return variables
-    return variables.filterKeys { variableFilter.filter(processDefinitionKey, taskDefinitionKey, it) }
+    return variables.filterKeys { variableFilter.filter(taskDefinitionKey, it) }
   }
 }
 
@@ -33,10 +33,8 @@ data class ProcessVariableFilter(
 
   constructor(filterType: FilterType, processVariables: List<VariableName>): this(null, filterType, processVariables)
 
-  override fun filter(processDefinitionKey: ProcessDefinitionKey, taskDefinitionKey: TaskDefinitionKey, variableName: VariableName): Boolean {
-    // this filter applies if it has either no process definition key, or the same process definition key as that process to which the given variable belongs
-    return if (this.processDefinitionKey != null && processDefinitionKey != this.processDefinitionKey) true
-      else (filterType == FilterType.INCLUDE) == processVariables.contains(variableName)
+  override fun filter(taskDefinitionKey: TaskDefinitionKey, variableName: VariableName): Boolean {
+    return (filterType == FilterType.INCLUDE) == processVariables.contains(variableName)
   }
 
 }
@@ -51,10 +49,7 @@ data class TaskVariableFilter(
   val taskVariables: Map<TaskDefinitionKey, List<VariableName>> = emptyMap()
 ): VariableFilter {
 
-  override fun filter(processDefinitionKey: ProcessDefinitionKey, taskDefinitionKey: TaskDefinitionKey, variableName: VariableName): Boolean {
-    if (processDefinitionKey != this.processDefinitionKey) {
-      return true
-    }
+  override fun filter(taskDefinitionKey: TaskDefinitionKey, variableName: VariableName): Boolean {
     val taskFilter = taskVariables[taskDefinitionKey] ?: return true
     return (filterType == FilterType.INCLUDE) == taskFilter.contains(variableName)
   }
@@ -70,11 +65,10 @@ interface VariableFilter {
 
   /**
    * Returns whether or not the process variable with the given name shall be contained in the payload of the given task.
-   * @param processDefinitionKey the key of process to which the task belongs
    * @param taskDefinitionKey the key of the task to be enriched
    * @param variableName the name of the process variable
    */
-  fun filter(processDefinitionKey: ProcessDefinitionKey, taskDefinitionKey: TaskDefinitionKey, variableName: VariableName): Boolean
+  fun filter(taskDefinitionKey: TaskDefinitionKey, variableName: VariableName): Boolean
 
 }
 

--- a/engine/taskpool-collector/src/main/kotlin/io/holunda/camunda/taskpool/enricher/ProcessVariablesTaskCommandEnricherFilter.kt
+++ b/engine/taskpool-collector/src/main/kotlin/io/holunda/camunda/taskpool/enricher/ProcessVariablesTaskCommandEnricherFilter.kt
@@ -2,6 +2,10 @@ package io.holunda.camunda.taskpool.enricher
 
 import org.camunda.bpm.engine.variable.VariableMap
 
+/**
+ * Groups one or more {@linkplain VariableFilter process variable filters}. Assumes (but does not enforce) that among the given individual filter instances,
+ * at most one is contained for any specific process, and at most one "global" filter (that is applied to all processes) is contained.
+ */
 class ProcessVariablesFilter(
   vararg variableFilters: VariableFilter
 ) {
@@ -16,6 +20,11 @@ class ProcessVariablesFilter(
   }
 }
 
+/**
+ * This filter allows to either explicitly include (whitelist) or exclude (blacklist) process variables for all user tasks of a certain
+ * process (if a process definition key is given), or for all user tasks of <i>all</i> processes (if no process definition key is given).
+ * If a differentiation between individual user tasks of a process is required, use a {@link TaskVariableFilter} instead.
+ */
 data class ProcessVariableFilter(
   override val processDefinitionKey: ProcessDefinitionKey?,
   val filterType: FilterType,
@@ -32,6 +41,10 @@ data class ProcessVariableFilter(
 
 }
 
+/**
+ * This filter allows to either explicitly include (whitelist) or exclude (blacklist) process variables for user tasks of a certain process.
+ * If the differentiation between individual user tasks is not required, use a {@link ProcessVariableFilter} instead.
+ */
 data class TaskVariableFilter(
   override val processDefinitionKey: ProcessDefinitionKey,
   val filterType: FilterType,
@@ -48,10 +61,19 @@ data class TaskVariableFilter(
 
 }
 
+/**
+ * To be implemented by classes that filter process variables. Used during enrichment to decide which process variables are added to a task's payload.
+ */
 interface VariableFilter {
 
   val processDefinitionKey: ProcessDefinitionKey?
 
+  /**
+   * Returns whether or not the process variable with the given name shall be contained in the payload of the given task.
+   * @param processDefinitionKey the key of process to which the task belongs
+   * @param taskDefinitionKey the key of the task to be enriched
+   * @param variableName the name of the process variable
+   */
   fun filter(processDefinitionKey: ProcessDefinitionKey, taskDefinitionKey: TaskDefinitionKey, variableName: VariableName): Boolean
 
 }

--- a/engine/taskpool-collector/src/test/kotlin/io/holunda/camunda/taskpool/enricher/ProcessVariablesFilterTest.kt
+++ b/engine/taskpool-collector/src/test/kotlin/io/holunda/camunda/taskpool/enricher/ProcessVariablesFilterTest.kt
@@ -30,10 +30,21 @@ class ProcessVariablesFilterTest {
       ))
     )
 
+    // verify filter for task1 of process7411
     assertThat(filter.filterVariables("process7411", "task1", variables)).containsOnlyKeys("business_var1", "business_var2")
+    // verify filter for task2 of process7411
     assertThat(filter.filterVariables("process7411", "task2", variables)).containsOnlyKeys("business_var3", "business_var2")
+    // verify that no filter is applied for task3 of process7411
+    assertThat(filter.filterVariables("process7411", "task3", variables))
+      .containsOnlyKeys("business_var1", "business_var2", "business_var3", "business_var4", "business_var12", "business_var32", "business_var42", "business_var51")
+
+    // verify filter for task3 of process7412
     assertThat(filter.filterVariables("process7412", "task3", variables)).containsOnlyKeys("business_var1", "business_var2", "business_var3", "business_var4", "business_var12", "business_var32")
+    // verify filter for task1 of process7412
     assertThat(filter.filterVariables("process7412", "task1", variables)).containsOnlyKeys("business_var1", "business_var2", "business_var3", "business_var4", "business_var51", "business_var42")
+    // verify that no filter is applied for task2 of process7412
+    assertThat(filter.filterVariables("process7412", "task2", variables))
+      .containsOnlyKeys("business_var1", "business_var2", "business_var3", "business_var4", "business_var12", "business_var32", "business_var42", "business_var51")
   }
 
   @Test
@@ -43,11 +54,15 @@ class ProcessVariablesFilterTest {
       ProcessVariableFilter("process7412", FilterType.EXCLUDE, listOf("business_var51", "business_var42", "business_var32", "business_var12"))
     )
 
-    // only 1, 2
+    // for process7411: only 1, 2
     assertThat(filter.filterVariables("process7411", "task77", variables)).containsOnlyKeys("business_var1", "business_var2")
 
-    // not 12, 32, 42, 52 -> 1, 2, 3, 4
+    // for process7412: not 12, 32, 42, 52 -> 1, 2, 3, 4
     assertThat(filter.filterVariables("process7412", "task88", variables)).containsOnlyKeys("business_var1", "business_var2", "business_var3", "business_var4")
+
+    // for process7413: all variables
+    assertThat(filter.filterVariables("process7413", "task88", variables))
+      .containsOnlyKeys("business_var1", "business_var2", "business_var3", "business_var4", "business_var12", "business_var32", "business_var42", "business_var51")
   }
 
   @Test

--- a/engine/taskpool-collector/src/test/kotlin/io/holunda/camunda/taskpool/enricher/ProcessVariablesFilterTest.kt
+++ b/engine/taskpool-collector/src/test/kotlin/io/holunda/camunda/taskpool/enricher/ProcessVariablesFilterTest.kt
@@ -19,12 +19,12 @@ class ProcessVariablesFilterTest {
 
   @Test
   fun `should filter for task`() {
-    val filter: ProcessVariablesFilter = ProcessVariablesFilter(
-      ProcessVariableFilter("process7411", FilterType.INCLUDE, mapOf(
+    val filter = ProcessVariablesFilter(
+      TaskVariableFilter("process7411", FilterType.INCLUDE, mapOf(
         "task1" to listOf("business_var1", "business_var2"),
         "task2" to listOf("business_var3", "business_var2")
       )),
-      ProcessVariableFilter("process7412", FilterType.EXCLUDE, mapOf(
+      TaskVariableFilter("process7412", FilterType.EXCLUDE, mapOf(
         "task3" to listOf("business_var51", "business_var42"),
         "task1" to listOf("business_var12", "business_var32")
       ))
@@ -37,10 +37,10 @@ class ProcessVariablesFilterTest {
   }
 
   @Test
-  fun `should filter globally`() {
-    val filter: ProcessVariablesFilter = ProcessVariablesFilter(
-      ProcessVariableFilter("process7411", FilterType.PROCESS_INCLUDE, emptyMap(), listOf("business_var1", "business_var2")),
-      ProcessVariableFilter("process7412", FilterType.PROCESS_EXCLUDE, emptyMap(), listOf("business_var51", "business_var42", "business_var32", "business_var12"))
+  fun `should filter for specific process`() {
+    val filter = ProcessVariablesFilter(
+      ProcessVariableFilter("process7411", FilterType.INCLUDE, listOf("business_var1", "business_var2")),
+      ProcessVariableFilter("process7412", FilterType.EXCLUDE, listOf("business_var51", "business_var42", "business_var32", "business_var12"))
     )
 
     // only 1, 2
@@ -50,4 +50,17 @@ class ProcessVariablesFilterTest {
     assertThat(filter.filterVariables("process7412", "task88", variables)).containsOnlyKeys("business_var1", "business_var2", "business_var3", "business_var4")
   }
 
+  @Test
+  fun `should filter for all processes`() {
+    val filter = ProcessVariablesFilter(
+      ProcessVariableFilter(FilterType.INCLUDE, listOf("business_var1", "business_var2")),
+      ProcessVariableFilter("process7412", FilterType.INCLUDE, listOf("business_var1", "business_var3", "business_var4"))
+    )
+
+    // process without dedicated filter -> use common filter -> include only 1, 2
+    assertThat(filter.filterVariables("process7411", "task77", variables)).containsOnlyKeys("business_var1", "business_var2")
+
+    // process with dedicated filter -> include only 1, 3, 4
+    assertThat(filter.filterVariables("process7412", "task88", variables)).containsOnlyKeys("business_var1", "business_var3", "business_var4")
+  }
 }

--- a/examples/process-application/src/main/kotlin/io/holunda/camunda/taskpool/example/process/ExampleProcessApplication.kt
+++ b/examples/process-application/src/main/kotlin/io/holunda/camunda/taskpool/example/process/ExampleProcessApplication.kt
@@ -1,7 +1,11 @@
 package io.holunda.camunda.taskpool.example.process
 
 import io.holunda.camunda.taskpool.EnableTaskpoolEngineSupport
-import io.holunda.camunda.taskpool.enricher.*
+import io.holunda.camunda.taskpool.enricher.FilterType
+import io.holunda.camunda.taskpool.enricher.ProcessVariableCorrelation
+import io.holunda.camunda.taskpool.enricher.ProcessVariablesCorrelator
+import io.holunda.camunda.taskpool.enricher.ProcessVariablesFilter
+import io.holunda.camunda.taskpool.enricher.TaskVariableFilter
 import io.holunda.camunda.taskpool.example.process.process.ProcessApproveRequest
 import io.holunda.camunda.taskpool.example.process.service.BusinessDataEntry
 import io.holunda.camunda.taskpool.example.users.EnableExampleUsers
@@ -27,13 +31,13 @@ class ExampleProcessApplication {
   @Bean
   fun processVariablesFilter(): ProcessVariablesFilter = ProcessVariablesFilter(
 
-    // define a applyFilter for every process
-    ProcessVariableFilter(
+    // define a variable filter for every process
+    TaskVariableFilter(
       ProcessApproveRequest.KEY,
       FilterType.INCLUDE,
       mapOf(
 
-        // define a applyFilter for every task
+        // define a variable filter for every task
         ProcessApproveRequest.Elements.APPROVE_REQUEST to
           listOf(
             ProcessApproveRequest.Variables.REQUEST_ID,

--- a/examples/process-application/src/main/kotlin/io/holunda/camunda/taskpool/example/process/web/TestClass.java
+++ b/examples/process-application/src/main/kotlin/io/holunda/camunda/taskpool/example/process/web/TestClass.java
@@ -3,12 +3,11 @@ package io.holunda.camunda.taskpool.example.process.web;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.holunda.camunda.taskpool.enricher.FilterType;
-import io.holunda.camunda.taskpool.enricher.ProcessVariableFilter;
 import io.holunda.camunda.taskpool.enricher.ProcessVariablesFilter;
+import io.holunda.camunda.taskpool.enricher.TaskVariableFilter;
 import io.holunda.camunda.taskpool.example.process.process.ProcessApproveRequest;
 import org.springframework.context.annotation.Bean;
 
-import java.util.Collections;
 import java.util.List;
 
 public class TestClass {
@@ -17,15 +16,15 @@ public class TestClass {
   public ProcessVariablesFilter myProcessVariablesFilter() {
 
     return new ProcessVariablesFilter(
-      // define a applyFilter for every process
-      new ProcessVariableFilter[]{
+      // define a variable filter for every process
+      new TaskVariableFilter[]{
         // for every process definition
-        new ProcessVariableFilter(
+        new TaskVariableFilter(
           ProcessApproveRequest.KEY,
           // filter type
           FilterType.INCLUDE,
           ImmutableMap.<String, List<String>>builder()
-            // define a applyFilter for every task
+            // define a variable filter for every task
             .put(ProcessApproveRequest.Elements.APPROVE_REQUEST, Lists.newArrayList(
               ProcessApproveRequest.Variables.REQUEST_ID,
               ProcessApproveRequest.Variables.ORIGINATOR)
@@ -35,10 +34,9 @@ public class TestClass {
               ProcessApproveRequest.Variables.REQUEST_ID,
               ProcessApproveRequest.Variables.COMMENT,
               ProcessApproveRequest.Variables.APPLICANT)
-            ).build(),
-          Collections.emptyList()
+            ).build()
         )
-      }, Collections.emptyMap()
+      }
     );
   }
 


### PR DESCRIPTION
Note: existing definitions of `ProcessVariablesFilter` beans need to be adjusted in Process Applications that use the taskpool. See ExampleProcessApplication.