### PR TITLE
chore: update dom4j dependency

### DIFF
--- a/datapool/datapool-core/pom.xml
+++ b/datapool/datapool-core/pom.xml
@@ -30,9 +30,9 @@
     </dependency>
     <!-- DOM4J for upcasters -->
     <dependency>
-      <groupId>dom4j</groupId>
+      <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
-      <version>1.6.1</version>
+      <version>2.1.3</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Note: I couldn't build this locally due to the dependency on spring fox 3.0.0-SNAPSHOT. Changing to 3.0.0 helped and local build succeeded, however I didn't want to commit that change because it's unrelated and I'm not sure if there's a reason for using the SNAPSHOT over the Release.

Should fix #238