### PR TITLE
Implemented queries for JPA view task service to get tasks with correlated data entries

### DIFF
--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/data/DataEntryRepository.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/data/DataEntryRepository.kt
@@ -25,7 +25,9 @@ interface DataEntryRepository : CrudRepository<DataEntryEntity, DataEntryId>, Jp
     fun hasEntryId(entryId: String): Specification<DataEntryEntity> =
       Specification { dataEntry, _, builder ->
         builder.equal(
-          dataEntry.get<DataEntryStateEmbeddable>(DataEntryId::entryId.name),
+          dataEntry
+            .get<DataEntryStateEmbeddable>(DataEntryEntity::dataEntryId.name)
+            .get<String>(DataEntryId::entryId.name),
           entryId
         )
       }
@@ -36,7 +38,9 @@ interface DataEntryRepository : CrudRepository<DataEntryEntity, DataEntryId>, Jp
     fun hasEntryType(entryType: String): Specification<DataEntryEntity> =
       Specification { dataEntry, _, builder ->
         builder.equal(
-          dataEntry.get<DataEntryStateEmbeddable>(DataEntryId::entryType.name),
+          dataEntry
+            .get<DataEntryStateEmbeddable>(DataEntryEntity::dataEntryId.name)
+            .get<String>(DataEntryId::entryType.name),
           entryType
         )
       }

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceTaskITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceTaskITest.kt
@@ -1,9 +1,13 @@
 package io.holunda.polyflow.view.jpa
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.holixon.axon.gateway.query.RevisionValue
+import io.holunda.camunda.taskpool.api.business.*
 import io.holunda.camunda.taskpool.api.task.TaskAssignedEngineEvent
 import io.holunda.camunda.taskpool.api.task.TaskCompletedEngineEvent
 import io.holunda.camunda.taskpool.api.task.TaskCreatedEngineEvent
+import io.holunda.camunda.variable.serializer.serialize
+import io.holunda.polyflow.view.DataEntry
 import io.holunda.polyflow.view.Task
 import io.holunda.polyflow.view.TaskWithDataEntries
 import io.holunda.polyflow.view.auth.User
@@ -30,6 +34,8 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import java.util.*
 import java.util.function.Predicate
 
@@ -37,7 +43,7 @@ import java.util.function.Predicate
 @SpringBootTest(
   classes = [TestApplication::class],
   properties = [
-    "polyflow.view.jpa.stored-items=TASK"
+    "polyflow.view.jpa.stored-items=TASK,data-entry"
   ]
 )
 @ActiveProfiles("itest", "mock-query-emitter")
@@ -53,6 +59,9 @@ internal class JpaPolyflowViewServiceTaskITest {
   lateinit var jpaPolyflowViewService: JpaPolyflowViewTaskService
 
   @Autowired
+  lateinit var jpaPolyflowViewDataEntryService: JpaPolyflowViewDataEntryService
+
+  @Autowired
   lateinit var dbCleaner: DbCleaner
 
   @Autowired
@@ -60,6 +69,12 @@ internal class JpaPolyflowViewServiceTaskITest {
 
   private val id = UUID.randomUUID().toString()
   private val id2 = UUID.randomUUID().toString()
+  private val id3 = UUID.randomUUID().toString()
+  private val id4 = UUID.randomUUID().toString()
+  private val dataId1 = UUID.randomUUID().toString()
+  private val dataType1 = "io.polyflow.test1"
+  private val dataId2 = UUID.randomUUID().toString()
+  private val dataType2 = "io.polyflow.test2"
   private val now = Instant.now()
 
   @Before
@@ -72,6 +87,17 @@ internal class JpaPolyflowViewServiceTaskITest {
         attribute2 = Date.from(now)
       )
     )
+
+    val dataEntry = DataEntry(
+      entryType = "entryType",
+      entryId = "entryId",
+      name = "name",
+      type = "type",
+      applicationName = "applicationName",
+      description = "description"
+    )
+
+
 
     jpaPolyflowViewService.on(
       event = TaskCreatedEngineEvent(
@@ -135,6 +161,87 @@ internal class JpaPolyflowViewServiceTaskITest {
       ), metaData = MetaData.emptyInstance()
     )
 
+    // for testing: fun query(query: TaskWithDataEntriesForIdQuery)
+    jpaPolyflowViewService.on(
+      event = TaskCreatedEngineEvent(
+        id = id3,
+        taskDefinitionKey = "task.def.0815",
+        name = "task name 3",
+        priority = 10,
+        sourceReference = processReference().toSourceReference(),
+        payload = createVariables().apply { putAll(payload) },
+        correlations = newCorrelations().apply { put(dataType1, dataId1) },
+        businessKey = "business-3",
+        createTime = Date.from(now),
+        candidateUsers = setOf("luffy"),
+        candidateGroups = setOf("strawhats")
+      ), metaData = MetaData.emptyInstance()
+    )
+
+    jpaPolyflowViewDataEntryService.on(
+      event = DataEntryCreatedEvent(
+        entryType = dataType1,
+        entryId = dataId1,
+        type = "Test",
+        applicationName = "test-application",
+        name = "Test Entry 1",
+        state = ProcessingType.IN_PROGRESS.of("In progress"),
+        payload = serialize(payload = payload, mapper = objectMapper),
+        authorizations = listOf(
+          AuthorizationChange.addUser("luffy"),
+          AuthorizationChange.addGroup("strawhats")
+        ),
+        createModification = Modification(
+          time = OffsetDateTime.ofInstant(now, ZoneOffset.UTC),
+          username = "luffy",
+          log = "strawhats",
+          logNotes = "Created the entry"
+        )
+      ),
+      metaData = RevisionValue(revision = 1).toMetaData()
+    )
+
+    // for testing: fun query(query: TasksWithDataEntriesForUserQuery)
+    jpaPolyflowViewService.on(
+      event = TaskCreatedEngineEvent(
+        id = id4,
+        taskDefinitionKey = "task.def.0815",
+        name = "task name 4",
+        priority = 10,
+        sourceReference = processReference().toSourceReference(),
+        payload = createVariables().apply { putAll(payload) },
+        correlations = newCorrelations().apply {
+          put(dataType1, dataId1)
+          put(dataType2, dataId2)
+        },
+        businessKey = "business-4",
+        createTime = Date.from(now),
+        candidateUsers = setOf("zoro"),
+        candidateGroups = setOf("strawhats")
+      ), metaData = MetaData.emptyInstance()
+    )
+
+    jpaPolyflowViewDataEntryService.on(
+      event = DataEntryCreatedEvent(
+        entryType = dataType2,
+        entryId = dataId2,
+        type = "Test",
+        applicationName = "test-application",
+        name = "Test Entry 1",
+        state = ProcessingType.IN_PROGRESS.of("In progress"),
+        payload = serialize(payload = payload, mapper = objectMapper),
+        authorizations = listOf(
+          AuthorizationChange.addUser("zoro")
+        ),
+        createModification = Modification(
+          time = OffsetDateTime.ofInstant(now, ZoneOffset.UTC),
+          username = "zoro",
+          log = "Created",
+          logNotes = "Created the entry"
+        )
+      ),
+      metaData = RevisionValue(revision = 1).toMetaData()
+    )
   }
 
   @After
@@ -154,9 +261,28 @@ internal class JpaPolyflowViewServiceTaskITest {
 
   @Test
   fun `should find the task with data entries by id`() {
-    val byId1 = jpaPolyflowViewService.query(TaskWithDataEntriesForIdQuery(id = id))
-    assertThat(byId1).isNotNull
-    assertThat(byId1!!.task.id).isEqualTo(id)
+    val byId3 = jpaPolyflowViewService.query(TaskWithDataEntriesForIdQuery(id = id3))
+    assertThat(byId3).isNotNull
+    assertThat(byId3!!.task.id).isEqualTo(id3)
+    assertThat(byId3.dataEntries).isNotEmpty.hasSize(1)
+    assertThat(byId3.dataEntries.first().entryId).isEqualTo(dataId1)
+  }
+
+  @Test
+  fun `should find the task by user with data entries`() {
+    val zoro = jpaPolyflowViewService.query(TasksWithDataEntriesForUserQuery(user = User("zoro", setOf())))
+    assertThat(zoro.elements).isNotEmpty.hasSize(1)
+    assertThat(zoro.elements[0].task.id).isEqualTo(id4)
+    assertThat(zoro.elements[0].task.name).isEqualTo("task name 4")
+    assertThat(zoro.elements[0].dataEntries).isNotEmpty.hasSize(1);
+    assertThat(zoro.elements[0].dataEntries[0].entryId).isEqualTo(dataId2);
+    val strawhats = jpaPolyflowViewService.query(TasksWithDataEntriesForUserQuery(user = User("other", setOf("strawhats"))))
+    assertThat(strawhats.elements).isNotEmpty.hasSize(2)
+    assertThat(strawhats.elements.map { it.task.id }).contains(id3,id4)
+    assertThat(strawhats.elements[0].dataEntries).hasSize(1)
+    assertThat(strawhats.elements[0].dataEntries[0].entryId).isEqualTo(dataId1)
+    assertThat(strawhats.elements[1].dataEntries).hasSize(1)
+    assertThat(strawhats.elements[1].dataEntries[0].entryId).isEqualTo(dataId1)
   }
 
   @Test
@@ -173,7 +299,7 @@ internal class JpaPolyflowViewServiceTaskITest {
   @Test
   fun `query updates are sent`() {
     captureEmittedQueryUpdates()
-    assertThat(emittedQueryUpdates).hasSize(20)
+    assertThat(emittedQueryUpdates).hasSize(36)
 
     assertThat(emittedQueryUpdates.filter { it.queryType == TaskForIdQuery::class.java && it.asTask().id == id }).hasSize(2)
     assertThat(emittedQueryUpdates.filter { it.queryType == TaskForIdQuery::class.java && it.asTask().id == id2 }).hasSize(2)
@@ -202,7 +328,8 @@ internal class JpaPolyflowViewServiceTaskITest {
       it.queryType == TasksWithDataEntriesForUserQuery::class.java && it.asTaskWithDataEntriesQueryResult().elements.map { taskW -> taskW.task.id }.contains(id)
     }).hasSize(2)
     assertThat(emittedQueryUpdates.filter {
-      it.queryType == TasksWithDataEntriesForUserQuery::class.java && it.asTaskWithDataEntriesQueryResult().elements.map { taskW -> taskW.task.id }.contains(id2)
+      it.queryType == TasksWithDataEntriesForUserQuery::class.java && it.asTaskWithDataEntriesQueryResult().elements.map { taskW -> taskW.task.id }
+        .contains(id2)
     }).hasSize(2)
 
   }


### PR DESCRIPTION
Querying for tasks with data entries is now working for queries by task id and user.
For queries by user both tasks and data entries will be filtered by authorization checks

One remark: Haven’t added checks for added events to the JpaPolyflowViewServiceTaskITest.’query updates are sent’ test.