### PR TITLE
chore: fix depenendency to provided

### DIFF
--- a/integration/camunda-bpm/pom.xml
+++ b/integration/camunda-bpm/pom.xml
@@ -16,8 +16,6 @@
   <properties>
     <camunda-bpm.version>7.17.0</camunda-bpm.version>
     <camunda-bpm-assert.version>15.0.0</camunda-bpm-assert.version>
-    <!-- pin assert-core it because BPM Assert can't work with larger version -->
-    <assert-core.version>3.18.1</assert-core.version>
     <camunda-bpm-mockito.version>5.16.0</camunda-bpm-mockito.version>
   </properties>
 
@@ -73,13 +71,6 @@
         <version>${camunda-bpm-assert.version}</version>
         <scope>test</scope>
       </dependency>
-      <dependency>
-        <groupId>org.assertj</groupId>
-        <artifactId>assertj-core</artifactId>
-        <version>${assert-core.version}</version>
-        <scope>test</scope>
-      </dependency>
-
 
     </dependencies>
   </dependencyManagement>

--- a/integration/camunda-bpm/taskpool-collector/pom.xml
+++ b/integration/camunda-bpm/taskpool-collector/pom.xml
@@ -22,18 +22,23 @@
       <artifactId>polyflow-taskpool-sender</artifactId>
     </dependency>
 
+    <!-- Engine is provided -->
     <dependency>
       <groupId>org.camunda.bpm.springboot</groupId>
       <artifactId>camunda-bpm-spring-boot-starter</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-engine-rest-jaxrs2</artifactId>
+      <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
@@ -50,11 +55,8 @@
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-kotlin</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
 
+    <!-- Testing -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
I changed the scope of the engine to `provided`... Please verify that it solves the problem... There is also an issue on the example side to do so: https://github.com/holunda-io/polyflow-examples/issues/92