### PR TITLE
Task assignment

### DIFF
--- a/bom/parent/pom.xml
+++ b/bom/parent/pom.xml
@@ -18,10 +18,10 @@
   <url>https://github.com/holunda-io/camunda-bpm-taskpool/</url>
 
   <properties>
-    <springboot.version>2.7.7</springboot.version>
+    <springboot.version>2.7.10</springboot.version>
     <camunda-commons-typed-values.version>7.18.0</camunda-commons-typed-values.version>
 
-    <axon-bom.version>4.6.3</axon-bom.version>
+    <axon-bom.version>4.6.6</axon-bom.version>
 
     <axon-kotlin.version>4.7.0</axon-kotlin.version>
     <axon-gateway-extension.version>1.1.2</axon-gateway-extension.version>
@@ -29,10 +29,10 @@
     <awaitability.version>4.2.0</awaitability.version>
     <mockito-kotlin.version>4.1.0</mockito-kotlin.version>
     <jgiven.version>1.2.5</jgiven.version>
+    <jgiven-kotlin.version>1.2.5.0</jgiven-kotlin.version>
 
     <pattern.class.itest>**/*ITest.*</pattern.class.itest>
     <pattern.package.itest>**/itest/**/*.*</pattern.package.itest>
-    <jgiven-kotlin.version>1.2.5.0</jgiven-kotlin.version>
   </properties>
 
   <modules>

--- a/core/taskpool/taskpool-api/src/main/kotlin/io/holunda/camunda/taskpool/api/process/variable/ProcessVariableValue.kt
+++ b/core/taskpool/taskpool-api/src/main/kotlin/io/holunda/camunda/taskpool/api/process/variable/ProcessVariableValue.kt
@@ -8,7 +8,7 @@ import org.camunda.bpm.engine.variable.value.TypedValue
  */
 interface ProcessVariableValue {
   val type: ProcessVariableValueType
-  val value: Any
+  val value: Any?
 }
 
 /**
@@ -23,7 +23,7 @@ data class TypedValueProcessVariableValue(override val value: TypedValue)
  * Implementation of the process variable value, where the value itself is represented by a 'primitive' class.
  */
 data class PrimitiveProcessVariableValue(
-  override val value: Any
+  override val value: Any?
 ) : ProcessVariableValue {
   override val type: ProcessVariableValueType = ProcessVariableValueType.PRIMITIVE
 }
@@ -46,7 +46,7 @@ enum class ProcessVariableValueType {
    */
   TYPE_VALUE,
   /**
-   * Some of the types are native to serialize. These are:
+   * Some types are native to serialize. These are:
    * - Numbers (Integer, Float, Double)
    * - Boolean
    * - String

--- a/core/taskpool/taskpool-api/src/main/kotlin/io/holunda/camunda/taskpool/api/task/EngineTaskCommandFilter.kt
+++ b/core/taskpool/taskpool-api/src/main/kotlin/io/holunda/camunda/taskpool/api/task/EngineTaskCommandFilter.kt
@@ -1,0 +1,14 @@
+package io.holunda.camunda.taskpool.api.task
+
+import java.util.function.Predicate
+
+/**
+ * Filter for task commands.
+ */
+interface EngineTaskCommandFilter : Predicate<EngineTaskCommand> {
+  /**
+   * Tests if the task command should be sent.
+   * @return true, if command should be emitted. Defaults to false.
+   */
+  override fun test(t: EngineTaskCommand): Boolean = false
+}

--- a/core/taskpool/taskpool-api/src/main/kotlin/io/holunda/camunda/taskpool/api/task/EngineTaskCommandFilter.kt
+++ b/core/taskpool/taskpool-api/src/main/kotlin/io/holunda/camunda/taskpool/api/task/EngineTaskCommandFilter.kt
@@ -8,7 +8,8 @@ import java.util.function.Predicate
 interface EngineTaskCommandFilter : Predicate<EngineTaskCommand> {
   /**
    * Tests if the task command should be sent.
+   * @param engineTaskCommand commend to test.
    * @return true, if command should be emitted. Defaults to false.
    */
-  override fun test(t: EngineTaskCommand): Boolean = false
+  override fun test(engineTaskCommand: EngineTaskCommand): Boolean = false
 }

--- a/core/taskpool/taskpool-core/src/main/kotlin/io/holunda/polyflow/taskpool/core/task/TaskAggregate.kt
+++ b/core/taskpool/taskpool-core/src/main/kotlin/io/holunda/polyflow/taskpool/core/task/TaskAggregate.kt
@@ -24,8 +24,8 @@ class TaskAggregate() {
   private lateinit var id: String
   internal lateinit var task: Task
 
-  private var deleted = false
-  private var completed = false
+  internal var deleted = false
+  internal var completed = false
 
   /**
    * This a non-static handler for create command.
@@ -277,5 +277,4 @@ class TaskAggregate() {
   fun on(event: TaskDeletedEngineEvent) {
     this.deleted = true
   }
-
 }

--- a/core/taskpool/taskpool-core/src/main/kotlin/io/holunda/polyflow/taskpool/core/task/TaskAggregateEngineTaskCommandFilter.kt
+++ b/core/taskpool/taskpool-core/src/main/kotlin/io/holunda/polyflow/taskpool/core/task/TaskAggregateEngineTaskCommandFilter.kt
@@ -5,6 +5,8 @@ import io.holunda.camunda.taskpool.api.task.EngineTaskCommand
 import io.holunda.camunda.taskpool.api.task.EngineTaskCommandFilter
 import io.holunda.polyflow.taskpool.core.loadOptional
 import org.axonframework.eventsourcing.EventSourcingRepository
+import org.axonframework.messaging.GenericMessage
+import org.axonframework.messaging.unitofwork.DefaultUnitOfWork
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
@@ -26,9 +28,13 @@ class TaskAggregateEngineTaskCommandFilter(
     return when (engineTaskCommand) {
 
       is CreateTaskCommand -> {
-        eventSourcingRepository.loadOptional(engineTaskCommand.id)
-          .map { false } // if the task exists, the CreateCommand should not be emitted
-          .orElse(true) // if the task doesn't exist, emit the CreateTaskCommand
+
+       DefaultUnitOfWork.startAndGet(GenericMessage.asMessage(engineTaskCommand)).executeWithResult {
+          eventSourcingRepository.loadOptional(engineTaskCommand.id)
+            .map { false } // if the task exists, the CreateCommand should not be emitted
+            .orElse(true) // if the task doesn't exist, emit the CreateTaskCommand
+        }.payload
+
       }
 
       else -> false // reject all others

--- a/core/taskpool/taskpool-core/src/main/kotlin/io/holunda/polyflow/taskpool/core/task/TaskAggregateEngineTaskCommandFilter.kt
+++ b/core/taskpool/taskpool-core/src/main/kotlin/io/holunda/polyflow/taskpool/core/task/TaskAggregateEngineTaskCommandFilter.kt
@@ -1,0 +1,37 @@
+package io.holunda.polyflow.taskpool.core.task
+
+import io.holunda.camunda.taskpool.api.task.CreateTaskCommand
+import io.holunda.camunda.taskpool.api.task.EngineTaskCommand
+import io.holunda.camunda.taskpool.api.task.EngineTaskCommandFilter
+import io.holunda.polyflow.taskpool.core.loadOptional
+import org.axonframework.eventsourcing.EventSourcingRepository
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+/**
+ * Filter checking the tasks in the event store.
+ */
+@Component
+@ConditionalOnProperty(
+  prefix = "polyflow.integration.collector.camunda.task.importer",
+  name = ["task-filter-type"],
+  havingValue = "eventstore",
+  matchIfMissing = false
+)
+class TaskAggregateEngineTaskCommandFilter(
+  private val eventSourcingRepository: EventSourcingRepository<TaskAggregate>
+) : EngineTaskCommandFilter {
+
+  override fun test(engineTaskCommand: EngineTaskCommand): Boolean {
+    return when (engineTaskCommand) {
+
+      is CreateTaskCommand -> {
+        eventSourcingRepository.loadOptional(engineTaskCommand.id)
+          .map { false } // if the task exists, the CreateCommand should not be emitted
+          .orElse(true) // if the task doesn't exist, emit the CreateTaskCommand
+      }
+
+      else -> false // reject all others
+    }
+  }
+}

--- a/docs/reference-guide/components/camunda-taskpool-collector.md
+++ b/docs/reference-guide/components/camunda-taskpool-collector.md
@@ -236,16 +236,44 @@ and the process reaches the task `task_approve_request`, the task will get the f
 
 > Please note that the logger root hierarchy is `io.holunda.polyflow.taskpool.collector`
 
-| Message Code     | Severity | Logger*               | Description                                                                                                                 | Meaning |
-|------------------|----------|:----------------------|:----------------------------------------------------------------------------------------------------------------------------|:--------| 
-| `COLLECTOR-001`  | `INFO`   |                       | Task commands will be collected.                                                                                            |         |
-| `COLLECTOR-002`  | `INFO`   |                       | Task commands not be collected.                                                                                             |         |
-| `COLLECTOR-005`  | `TRACE`  | `.process.definition` | Sending process definition command: $command                                                                                |         |
-| `COLLECTOR-006`  | `TRACE`  | `.process.instance`   | Sending process instance command: $command                                                                                  |         |
-| `COLLECTOR-007`  | `TRACE`  | `.process.variable`   | Sending process variable command: $command                                                                                  |         |
-| `COLLECTOR-008`  | `TRACE`  | `.task`               | Sending engine task command: $command.                                                                                      |         |
-| `ENRICHER-001`   | `INFO`   |                       | Task commands will be enriched with process variables.                                                                      |         |
-| `ENRICHER-002`   | `INFO`   |                       | Task commands will not be enriched.                                                                                         |         |
-| `ENRICHER-003`   | `INFO`   |                       | Task commands will be enriched by a custom enricher.                                                                        |         |
-| `ENRICHER-004`   | `DEBUG`  | `.task.enricher`      | Could not enrich variables from running execution ${command.sourceReference.executionId}, since it doesn't exist (anymore). |         |
+| Message Code     | Severity | Logger*               | Description                                                                                                                 | Meaning  |
+|------------------|----------|:----------------------|:----------------------------------------------------------------------------------------------------------------------------|:---------| 
+| `COLLECTOR-001`  | `INFO`   |                       | Task commands will be collected.                                                                                            |          |
+| `COLLECTOR-002`  | `INFO`   |                       | Task commands not be collected.                                                                                             |          |
+| `COLLECTOR-005`  | `TRACE`  | `.process.definition` | Sending process definition command: $command                                                                                |          |
+| `COLLECTOR-006`  | `TRACE`  | `.process.instance`   | Sending process instance command: $command                                                                                  |          |
+| `COLLECTOR-007`  | `TRACE`  | `.process.variable`   | Sending process variable command: $command                                                                                  |          |
+| `COLLECTOR-008`  | `TRACE`  | `.task`               | Sending engine task command: $command.                                                                                      |          |
+| `ENRICHER-001`   | `INFO`   |                       | Task commands will be enriched with process variables.                                                                      |          |
+| `ENRICHER-002`   | `INFO`   |                       | Task commands will not be enriched.                                                                                         |          |
+| `ENRICHER-003`   | `INFO`   |                       | Task commands will be enriched by a custom enricher.                                                                        |          |
+| `ENRICHER-004`   | `DEBUG`  | `.task.enricher`      | Could not enrich variables from running execution ${command.sourceReference.executionId}, since it doesn't exist (anymore). |          |
 
+### Task Assignment
+
+User task assignment is a core functionality for every process application fostering task oriented work. By default, Taskpool Collector uses
+information from Camunda User Task and maps that one-to-one to properties of the user task commands. The task attribute
+`assignee`, `candidateUsers` and `candidateGroups` are mapped to the corresponding attributes automatically.
+
+To control the task assignment mode you can configure taskpool collector using application properties. The property 
+`polyflow.integration.collector.camunda.task.assigner.type` has the following values:
+
+* `no`: No additional assignment takes place, the Camunda task attributes are used (default)
+* `process-variables`: Use process variables for assignment information, see below
+* `custom`: User provides own implementation implementing a bean implementing `TaskAssigner` interface.
+
+If the value is set to `process-variables`, you can set up a constant mapping defining the process variables carrying the assignment
+information. The corresponding properties are:
+
+```yaml
+polyflow:
+  integration:
+    collector:
+      camunda:
+        task:
+          assigner:
+            type: process-variables
+            assignee: my-assignee-var
+            candidateUsers: my-candidate-users-var 
+            candidateGroup: my-candidate-group-var
+```

--- a/docs/reference-guide/components/camunda-taskpool-collector.md
+++ b/docs/reference-guide/components/camunda-taskpool-collector.md
@@ -8,7 +8,7 @@ Taskpool Collector is a component deployed as a part of the process application
 (aside with Camunda BPM Engine) that is responsible for collecting information from
 the Camunda BPM Engine. It detects the _intent_ of the operations executed inside the engine
 and creates the corresponding commands for the Taskpool. The commands are enriched with data and transmitted to
-other taskpool components (via Command Bus).
+other Taskpool components (via Command Bus).
 
 In the following description, we use the terms _event_ and _command_. Event denotes an entity
 received from Camunda BPM Engine (from delegate event listener or from history event listener)
@@ -55,7 +55,7 @@ In order to enable collector component, include the Maven dependency to your pro
 
 ```
 
-Then activate the taskpool collector by providing the annotation on any Spring Configuration:
+Then activate the Taskpool collector by providing the annotation on any Spring Configuration:
 
 ```java
 @Configuration
@@ -277,3 +277,26 @@ polyflow:
             candidateUsers: my-candidate-users-var 
             candidateGroup: my-candidate-group-var
 ```
+
+### Task Importer
+
+Alongside with the event-based Task Collector based on Camunda Eventing, there exists a dedicated service which can query Camunda database for existing
+user tasks and publish the results. In order to avoid duplications in tasks, the collected tasks are filtered by a special filter. Currently, you may choose
+between the supplied `eventstore` filter or supply your own `custom` filter by providing your own implementation of a `EngineTaskCommandFilter` interface as 
+a Spring Bean. If you want to use this task importer facility, you need to activate it first in your application configuration.
+
+The following property block is used for configuration:
+
+```yaml
+polyflow:
+  integration:
+    collector:
+      camunda:
+        task:
+          importer:
+            enabled: true
+            task-filter-type: eventstore
+```
+
+By doing so, the `TaskServiceCollectorService` Bean is made available and can be used to trigger the import. The `eventstore` filter is useful in scenarios,
+in which the [Taskpool Core](./core-taskpool) is deployed on together with Taskpool Collector as part of the Process Application.

--- a/integration/camunda-bpm/engine-client/pom.xml
+++ b/integration/camunda-bpm/engine-client/pom.xml
@@ -22,7 +22,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.axonframework</groupId>
-          <artifactId>axon-server-conector</artifactId>
+          <artifactId>axon-server-connector</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/TaskEntityExtensions.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/TaskEntityExtensions.kt
@@ -1,8 +1,11 @@
 package io.holunda.polyflow.taskpool
 
+import io.holunda.camunda.taskpool.api.task.CreateTaskCommand
 import org.apache.commons.lang3.reflect.FieldUtils
+import org.camunda.bpm.engine.delegate.TaskListener
 import org.camunda.bpm.engine.impl.persistence.entity.PropertyChange
 import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity
+import org.camunda.bpm.engine.task.IdentityLinkType
 
 /**
  * Reads identity changes from the task entity.
@@ -23,3 +26,27 @@ fun TaskEntity.isAssigneeChange(): Boolean =
  * Checks if the task entity has changed properties.
  */
 fun TaskEntity.hasChangedProperties(): Boolean = this.propertyChanges.isNotEmpty()
+
+/**
+ * Creates a new CreateTaskCommand from this task entity. The resulting command has no correlations and is not enriched.
+ * @param applicationName application name.
+ * @return create task command.
+ */
+fun TaskEntity.asCreateCommand(applicationName: String) = CreateTaskCommand(
+    id = this.id,
+    assignee = this.assignee,
+    candidateGroups = this.candidates.filter { it.groupId != null }.map { it.groupId }.toSet(),
+    candidateUsers = this.candidates.filter { it.userId != null && it.type == IdentityLinkType.CANDIDATE }.map { it.userId }.toSet(),
+    createTime = this.createTime,
+    description = this.description,
+    dueDate = this.dueDate,
+    followUpDate = this.followUpDate,
+    eventName = TaskListener.EVENTNAME_CREATE,
+    name = this.name,
+    owner = this.owner,
+    priority = this.priority,
+    formKey = this.formKey(),
+    taskDefinitionKey = this.taskDefinitionKey,
+    businessKey = this.execution.businessKey,
+    sourceReference = this.sourceReference(applicationName)
+  )

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/CamundaTaskpoolCollectorProperties.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/CamundaTaskpoolCollectorProperties.kt
@@ -63,7 +63,14 @@ data class CamundaTaskCollectorProperties(
   /**
    * Flag to enable or disable the collector.
    */
-  val enabled: Boolean = true
+  val enabled: Boolean = true,
+
+  /**
+   * Properties of task importer.
+   */
+  @NestedConfigurationProperty
+  val importer: TaskImporterProperties = TaskImporterProperties()
+
 )
 
 /**
@@ -178,3 +185,26 @@ data class TaskAssignerProperties(
     candidateGroups = candidateGroups,
   )
 }
+
+@ConstructorBinding
+data class TaskImporterProperties (
+  /**
+   * Enables or disabled importer. Defaults to false.
+   */
+  val enabled: Boolean = false,
+
+  /**
+   * Configures the type of engine task command filter.
+   * Defaults to `eventstore` allowing co-located deployed Taskpool Core to be used as a reference to filter commands.
+   */
+  val taskFilterType: EngineTaskCommandFilterType = EngineTaskCommandFilterType.eventstore
+)
+
+/**
+ * Type
+ */
+enum class EngineTaskCommandFilterType {
+  eventstore,
+  custom
+}
+

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/CamundaTaskpoolCollectorProperties.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/CamundaTaskpoolCollectorProperties.kt
@@ -115,6 +115,9 @@ enum class TaskCollectorEnricherType {
   custom
 }
 
+/**
+ * Type of task assigner.
+ */
 enum class TaskAssignerType {
   /**
    * Empty assigner, use information from Camunda task.
@@ -179,6 +182,9 @@ data class TaskAssignerProperties(
    */
   val candidateGroups: String? = null
 ) {
+  /**
+   * Constructs mapping from properties.
+   */
   fun toMapping(): ProcessVariableTaskAssignerMapping = ProcessVariableTaskAssignerMapping(
     assignee = assignee,
     candidateUsers = candidateUsers,
@@ -186,8 +192,11 @@ data class TaskAssignerProperties(
   )
 }
 
+/**
+ * Configuration of the task importer.
+ */
 @ConstructorBinding
-data class TaskImporterProperties (
+data class TaskImporterProperties(
   /**
    * Enables or disabled importer. Defaults to false.
    */

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/CamundaTaskpoolCollectorProperties.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/CamundaTaskpoolCollectorProperties.kt
@@ -1,5 +1,6 @@
 package io.holunda.polyflow.taskpool.collector
 
+import io.holunda.polyflow.taskpool.collector.task.assigner.ProcessVariableTaskAssignerMapping
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding
@@ -52,6 +53,13 @@ data class CamundaTaskCollectorProperties(
    */
   @NestedConfigurationProperty
   val enricher: TaskCollectorEnricherProperties = TaskCollectorEnricherProperties(),
+
+  /**
+   * Task assigner properties.
+   */
+  @NestedConfigurationProperty
+  val assigner: TaskAssignerProperties = TaskAssignerProperties(),
+
   /**
    * Flag to enable or disable the collector.
    */
@@ -100,6 +108,23 @@ enum class TaskCollectorEnricherType {
   custom
 }
 
+enum class TaskAssignerType {
+  /**
+   * Empty assigner, use information from Camunda task.
+   */
+  no,
+
+  /**
+   * Use process variables for assignment information.
+   */
+  processVariables,
+
+  /**
+   * Custom assigner.
+   */
+  custom
+}
+
 /**
  * Properties controlling the transfer of process definitions deployments.
  */
@@ -124,3 +149,32 @@ data class CamundaProcessInstanceCollectorProperties(
    */
   val enabled: Boolean = true
 )
+
+/**
+ * Properties to set up the task assigner.
+ */
+@ConstructorBinding
+data class TaskAssignerProperties(
+  /**
+   * Configures assigner type.
+   */
+  val type: TaskAssignerType = TaskAssignerType.no,
+  /**
+   * Process variable carrying the assignee information used by the process variable task assigner.
+   */
+  val assignee: String? = null,
+  /**
+   * Process variable carrying the candidateUsers information used by the process variable task assigner.
+   */
+  val candidateUsers: String? = null,
+  /**
+   * Process variable carrying the candidateGroups information used by the process variable task assigner.
+   */
+  val candidateGroups: String? = null
+) {
+  fun toMapping(): ProcessVariableTaskAssignerMapping = ProcessVariableTaskAssignerMapping(
+    assignee = assignee,
+    candidateUsers = candidateUsers,
+    candidateGroups = candidateGroups,
+  )
+}

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskAssigner.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskAssigner.kt
@@ -1,0 +1,15 @@
+package io.holunda.polyflow.taskpool.collector.task
+
+import io.holunda.camunda.taskpool.api.task.EngineTaskCommand
+
+/**
+ * Hook for assignment changes.
+ */
+interface TaskAssigner {
+  /**
+   * Sets assignment of a task command.
+   * @param command task command
+   * @return command with modified assignment information.
+   */
+  fun setAssignment(command: EngineTaskCommand): EngineTaskCommand
+}

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskCollectorConfiguration.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskCollectorConfiguration.kt
@@ -100,7 +100,10 @@ class TaskCollectorConfiguration(
 
   @Bean
   @ConditionalOnExpression("'\${polyflow.integration.collector.camunda.task.assigner.type}' == 'process-variables' && '\${polyflow.integration.collector.camunda.process-variable.enabled}'")
-  fun processVariableChangeAssigningService() = ProcessVariableChangeAssigningService(camundaTaskpoolCollectorProperties.task.assigner.toMapping())
+  fun processVariableChangeAssigningService(taskService: TaskService) = ProcessVariableChangeAssigningService(
+    taskService = taskService,
+    mapping = camundaTaskpoolCollectorProperties.task.assigner.toMapping()
+  )
 
   /**
    * Constructs the task collector service responsible for collecting Camunda Spring events and building commands out of them.

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskCollectorConfiguration.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskCollectorConfiguration.kt
@@ -101,6 +101,9 @@ class TaskCollectorConfiguration(
       else -> throw IllegalStateException("Could not initialize task assigner, used unknown ${camundaTaskpoolCollectorProperties.task.assigner.type} type.")
     }
 
+  /**
+   * Service reposnsible for changing assignees on process variable change.
+   */
   @Bean
   @ConditionalOnExpression("'\${polyflow.integration.collector.camunda.task.assigner.type}' == 'process-variables' && '\${polyflow.integration.collector.camunda.process-variable.enabled}'")
   fun processVariableChangeAssigningService(taskService: TaskService) = ProcessVariableChangeAssigningService(

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskCollectorConfiguration.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskCollectorConfiguration.kt
@@ -141,6 +141,7 @@ class TaskCollectorConfiguration(
   @ConditionalOnProperty(value = ["polyflow.integration.collector.camunda.task.importer.enabled"], havingValue = "true", matchIfMissing = false)
   fun taskServiceCollectorService(
     taskService: TaskService,
+    commandExecutor: CommandExecutor,
     applicationEventPublisher: ApplicationEventPublisher,
     @Autowired(required = false) engineTaskCommandFilter: EngineTaskCommandFilter?
   ): TaskServiceCollectorService {
@@ -151,6 +152,7 @@ class TaskCollectorConfiguration(
 
     return TaskServiceCollectorService(
       taskService = taskService,
+      commandExecutor = commandExecutor,
       camundaTaskpoolCollectorProperties = camundaTaskpoolCollectorProperties,
       applicationEventPublisher = applicationEventPublisher,
       engineTaskCommandFilter = engineTaskCommandFilter ?: object : EngineTaskCommandFilter {}

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskCollectorConfiguration.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskCollectorConfiguration.kt
@@ -102,7 +102,7 @@ class TaskCollectorConfiguration(
     }
 
   /**
-   * Service reposnsible for changing assignees on process variable change.
+   * Service responsible for changing assignees on process variable change.
    */
   @Bean
   @ConditionalOnExpression("'\${polyflow.integration.collector.camunda.task.assigner.type}' == 'process-variables' && '\${polyflow.integration.collector.camunda.process-variable.enabled}'")

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskCommandProcessor.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskCommandProcessor.kt
@@ -14,7 +14,8 @@ import org.springframework.context.event.EventListener
  */
 class TaskCommandProcessor(
   private val engineTaskCommandSender: EngineTaskCommandSender,
-  private val enricher: VariablesEnricher
+  private val enricher: VariablesEnricher,
+  private val taskAssigner: TaskAssigner
 ) {
   companion object : KLogging()
 
@@ -27,6 +28,8 @@ class TaskCommandProcessor(
     when (command) {
       is TaskIdentityWithPayloadAndCorrelations -> enricher.enrich(command)
       else -> command
+    }.let {
+      taskAssigner.setAssignment(it)
     }.also { commandToSend ->
       if (logger.isTraceEnabled) {
         logger.trace("COLLECTOR-008: Sending engine task command: $commandToSend.")

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskEventCollectorService.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskEventCollectorService.kt
@@ -30,7 +30,7 @@ class TaskEventCollectorService(
   /**
    * Tracing of collector.
    */
-  @Order(ORDER)
+  @Order(ORDER - 10)
   @EventListener
   fun all(task: DelegateTask) {
     if (logger.isTraceEnabled) {

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskEventCollectorService.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskEventCollectorService.kt
@@ -99,7 +99,6 @@ class TaskEventCollectorService(
       eventName = task.eventName
     )
 
-
   /**
    * Fires update command.
    */

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskServiceCollectorService.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskServiceCollectorService.kt
@@ -1,19 +1,16 @@
 package io.holunda.polyflow.taskpool.collector.task
 
-import io.holunda.camunda.taskpool.api.task.CreateTaskCommand
 import io.holunda.camunda.taskpool.api.task.EngineTaskCommandFilter
+import io.holunda.polyflow.taskpool.asCreateCommand
 import io.holunda.polyflow.taskpool.callInProcessEngineContext
 import io.holunda.polyflow.taskpool.collector.CamundaTaskpoolCollectorProperties
-import io.holunda.polyflow.taskpool.formKey
-import io.holunda.polyflow.taskpool.sourceReference
+import io.holunda.polyflow.view.query.PageableSortableQuery
 import org.camunda.bpm.engine.TaskService
-import org.camunda.bpm.engine.delegate.TaskListener
 import org.camunda.bpm.engine.impl.db.entitymanager.DbEntityManager
 import org.camunda.bpm.engine.impl.interceptor.CommandContext
 import org.camunda.bpm.engine.impl.interceptor.CommandContextListener
 import org.camunda.bpm.engine.impl.interceptor.CommandExecutor
 import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity
-import org.camunda.bpm.engine.task.IdentityLinkType
 import org.springframework.context.ApplicationEventPublisher
 
 /**
@@ -32,11 +29,13 @@ class TaskServiceCollectorService(
    * sends commands for all which are not filtered away by the filter.
    * In combination with [TaskAggregateEngineTaskCommandFilter] this can be used to initialize
    * the event store with tasks from the engine.
+   * @param activeOnly parameter controlling if only active tasks are collected.
+   * @param firstResult first result of filtered command list to be sent
+   * @param maxResults last result of filtered command list to be sent
    */
-  fun collectAndPopulateExistingTasks() {
+  fun collectAndPopulateExistingTasks(activeOnly: Boolean = true, firstResult: Int = 0, maxResults: Int = 1000) {
     callInProcessEngineContext(newContext = true) {
       commandExecutor.execute { innerContext ->
-
         innerContext.registerCommandContextListener(object : CommandContextListener {
           override fun onCommandContextClose(commandContext: CommandContext) {
             // Remove all cached entities from the inner context because we don't want to accidentally flush any changes that could cause
@@ -52,32 +51,31 @@ class TaskServiceCollectorService(
           }
         })
 
+        // query
         val engineTasks = taskService
           .createTaskQuery()
           .initializeFormKeys()
-          .list()
-        val commands = engineTasks
-          .filterIsInstance<TaskEntity>()
-          .map { task ->
-            CreateTaskCommand(
-              id = task.id,
-              assignee = task.assignee,
-              candidateGroups = task.candidates.filter { it.groupId != null }.map { it.groupId }.toSet(),
-              candidateUsers = task.candidates.filter { it.userId != null && it.type == IdentityLinkType.CANDIDATE }.map { it.userId }.toSet(),
-              createTime = task.createTime,
-              description = task.description,
-              dueDate = task.dueDate,
-              eventName = TaskListener.EVENTNAME_CREATE,
-              name = task.name,
-              owner = task.owner,
-              priority = task.priority,
-              formKey = task.formKey(),
-              taskDefinitionKey = task.taskDefinitionKey,
-              businessKey = task.execution.businessKey,
-              sourceReference = task.sourceReference(camundaTaskpoolCollectorProperties.applicationName)
-            )
+          .let {
+            if (activeOnly) {
+              it.active()
+            } else {
+              it
+            }
+          }.list()
+
+        // create commands
+        val commands = engineTasks.filterIsInstance<TaskEntity>().map { task -> task.asCreateCommand(camundaTaskpoolCollectorProperties.applicationName) }
+
+        // filter and limit
+        val filtered = commands.filter { command -> engineTaskCommandFilter.test(command) }.let {
+          if (firstResult < it.size) {
+            it.subList(firstResult, maxResults.coerceAtMost(it.size))
+          } else {
+            it
           }
-        val filtered = commands.filter { command -> engineTaskCommandFilter.test(command) }
+        }
+
+        // publish
         filtered.forEach {
           applicationEventPublisher.publishEvent(it)
         }

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskServiceCollectorService.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskServiceCollectorService.kt
@@ -1,0 +1,74 @@
+package io.holunda.polyflow.taskpool.collector.task
+
+import io.holunda.camunda.taskpool.api.task.CreateTaskCommand
+import io.holunda.camunda.taskpool.api.task.EngineTaskCommand
+import io.holunda.camunda.taskpool.api.task.EngineTaskCommandFilter
+import io.holunda.polyflow.taskpool.collector.CamundaTaskpoolCollectorProperties
+import io.holunda.polyflow.taskpool.formKey
+import io.holunda.polyflow.taskpool.sourceReference
+import org.camunda.bpm.engine.TaskService
+import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity
+import org.camunda.bpm.engine.task.IdentityLinkType
+import org.camunda.bpm.engine.task.Task
+import org.springframework.context.ApplicationEventPublisher
+
+/**
+ * Service to collect tasks and fire the corresponding commands using Camunda Task Service.
+ */
+class TaskServiceCollectorService(
+  private val taskService: TaskService,
+  private val camundaTaskpoolCollectorProperties: CamundaTaskpoolCollectorProperties,
+  private val applicationEventPublisher: ApplicationEventPublisher,
+  private val engineTaskCommandFilter: EngineTaskCommandFilter
+) {
+
+  /**
+   * Collects tasks existing inm the Camunda task service
+   * sends commands for all which are not filtered away by the filter.
+   * In combination with [TaskAggregateEngineTaskCommandFilter] this can be used to initialize
+   * the event store with tasks from the engine.
+   */
+  fun collectAndPopulateExistingTasks() {
+    val engineTasks = loadExistingTasks()
+    val commands = convertToCommands(engineTasks)
+    val filtered = filterTasks(commands)
+    filtered.forEach {
+      applicationEventPublisher.publishEvent(it)
+    }
+  }
+
+  private fun filterTasks(engineTasks: List<EngineTaskCommand>): List<EngineTaskCommand> {
+    return engineTasks.filter { engineTaskCommandFilter.test(it) }
+  }
+
+  private fun loadExistingTasks(): List<Task> {
+    return taskService
+      .createTaskQuery()
+      .list()
+  }
+
+  private fun convertToCommands(tasks: List<Task>): List<CreateTaskCommand> {
+    return tasks
+      .filterIsInstance<TaskEntity>()
+      .map { task ->
+        CreateTaskCommand(
+          id = task.id,
+          assignee = task.assignee,
+          candidateGroups = task.candidates.filter { it.groupId != null }.map { it.groupId }.toSet(),
+          candidateUsers = task.candidates.filter { it.userId != null && it.type == IdentityLinkType.CANDIDATE }.map { it.userId }.toSet(),
+          createTime = task.createTime,
+          description = task.description,
+          dueDate = task.dueDate,
+          eventName = task.eventName,
+          name = task.name,
+          owner = task.owner,
+          priority = task.priority,
+          formKey = task.formKey(),
+          taskDefinitionKey = task.taskDefinitionKey,
+          businessKey = task.execution.businessKey,
+          sourceReference = task.sourceReference(camundaTaskpoolCollectorProperties.applicationName)
+        )
+      }
+  }
+
+}

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskServiceCollectorService.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskServiceCollectorService.kt
@@ -1,15 +1,19 @@
 package io.holunda.polyflow.taskpool.collector.task
 
 import io.holunda.camunda.taskpool.api.task.CreateTaskCommand
-import io.holunda.camunda.taskpool.api.task.EngineTaskCommand
 import io.holunda.camunda.taskpool.api.task.EngineTaskCommandFilter
+import io.holunda.polyflow.taskpool.callInProcessEngineContext
 import io.holunda.polyflow.taskpool.collector.CamundaTaskpoolCollectorProperties
 import io.holunda.polyflow.taskpool.formKey
 import io.holunda.polyflow.taskpool.sourceReference
 import org.camunda.bpm.engine.TaskService
+import org.camunda.bpm.engine.delegate.TaskListener
+import org.camunda.bpm.engine.impl.db.entitymanager.DbEntityManager
+import org.camunda.bpm.engine.impl.interceptor.CommandContext
+import org.camunda.bpm.engine.impl.interceptor.CommandContextListener
+import org.camunda.bpm.engine.impl.interceptor.CommandExecutor
 import org.camunda.bpm.engine.impl.persistence.entity.TaskEntity
 import org.camunda.bpm.engine.task.IdentityLinkType
-import org.camunda.bpm.engine.task.Task
 import org.springframework.context.ApplicationEventPublisher
 
 /**
@@ -17,6 +21,7 @@ import org.springframework.context.ApplicationEventPublisher
  */
 class TaskServiceCollectorService(
   private val taskService: TaskService,
+  private val commandExecutor: CommandExecutor,
   private val camundaTaskpoolCollectorProperties: CamundaTaskpoolCollectorProperties,
   private val applicationEventPublisher: ApplicationEventPublisher,
   private val engineTaskCommandFilter: EngineTaskCommandFilter
@@ -29,46 +34,54 @@ class TaskServiceCollectorService(
    * the event store with tasks from the engine.
    */
   fun collectAndPopulateExistingTasks() {
-    val engineTasks = loadExistingTasks()
-    val commands = convertToCommands(engineTasks)
-    val filtered = filterTasks(commands)
-    filtered.forEach {
-      applicationEventPublisher.publishEvent(it)
+    callInProcessEngineContext(newContext = true) {
+      commandExecutor.execute { innerContext ->
+
+        innerContext.registerCommandContextListener(object : CommandContextListener {
+          override fun onCommandContextClose(commandContext: CommandContext) {
+            // Remove all cached entities from the inner context because we don't want to accidentally flush any changes that could cause
+            // OptimisticLockingExceptions in the outer context.
+            // (We don't change any variables but there are situations where _reading_ a variable also causes a change, e.g. when the serialized form of a
+            // complex variable has changed because properties have been added since creation of the variable. Another example: A variable containing a Set
+            // has been created and serialized from a LinkedHashSet with a specific order, but is deserialized to a HashSet with a different iteration order.
+            // When this is serialized again, the serialized form will look different because the order has changed.
+            (commandContext.sessions[DbEntityManager::class.java] as? DbEntityManager)?.dbEntityCache?.apply { cachedEntities.forEach { remove(it) } }
+          }
+
+          override fun onCommandFailed(commandContext: CommandContext, t: Throwable) {
+          }
+        })
+
+        val engineTasks = taskService
+          .createTaskQuery()
+          .initializeFormKeys()
+          .list()
+        val commands = engineTasks
+          .filterIsInstance<TaskEntity>()
+          .map { task ->
+            CreateTaskCommand(
+              id = task.id,
+              assignee = task.assignee,
+              candidateGroups = task.candidates.filter { it.groupId != null }.map { it.groupId }.toSet(),
+              candidateUsers = task.candidates.filter { it.userId != null && it.type == IdentityLinkType.CANDIDATE }.map { it.userId }.toSet(),
+              createTime = task.createTime,
+              description = task.description,
+              dueDate = task.dueDate,
+              eventName = TaskListener.EVENTNAME_CREATE,
+              name = task.name,
+              owner = task.owner,
+              priority = task.priority,
+              formKey = task.formKey(),
+              taskDefinitionKey = task.taskDefinitionKey,
+              businessKey = task.execution.businessKey,
+              sourceReference = task.sourceReference(camundaTaskpoolCollectorProperties.applicationName)
+            )
+          }
+        val filtered = commands.filter { command -> engineTaskCommandFilter.test(command) }
+        filtered.forEach {
+          applicationEventPublisher.publishEvent(it)
+        }
+      }
     }
   }
-
-  private fun filterTasks(engineTasks: List<EngineTaskCommand>): List<EngineTaskCommand> {
-    return engineTasks.filter { engineTaskCommandFilter.test(it) }
-  }
-
-  private fun loadExistingTasks(): List<Task> {
-    return taskService
-      .createTaskQuery()
-      .list()
-  }
-
-  private fun convertToCommands(tasks: List<Task>): List<CreateTaskCommand> {
-    return tasks
-      .filterIsInstance<TaskEntity>()
-      .map { task ->
-        CreateTaskCommand(
-          id = task.id,
-          assignee = task.assignee,
-          candidateGroups = task.candidates.filter { it.groupId != null }.map { it.groupId }.toSet(),
-          candidateUsers = task.candidates.filter { it.userId != null && it.type == IdentityLinkType.CANDIDATE }.map { it.userId }.toSet(),
-          createTime = task.createTime,
-          description = task.description,
-          dueDate = task.dueDate,
-          eventName = task.eventName,
-          name = task.name,
-          owner = task.owner,
-          priority = task.priority,
-          formKey = task.formKey(),
-          taskDefinitionKey = task.taskDefinitionKey,
-          businessKey = task.execution.businessKey,
-          sourceReference = task.sourceReference(camundaTaskpoolCollectorProperties.applicationName)
-        )
-      }
-  }
-
 }

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskVariableLoader.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/TaskVariableLoader.kt
@@ -1,0 +1,89 @@
+package io.holunda.polyflow.taskpool.collector.task
+
+import io.holunda.camunda.taskpool.api.task.*
+import io.holunda.polyflow.taskpool.callInProcessEngineContext
+import mu.KLogging
+import org.camunda.bpm.engine.RuntimeService
+import org.camunda.bpm.engine.TaskService
+import org.camunda.bpm.engine.impl.db.entitymanager.DbEntityManager
+import org.camunda.bpm.engine.impl.interceptor.CommandContext
+import org.camunda.bpm.engine.impl.interceptor.CommandContextListener
+import org.camunda.bpm.engine.impl.interceptor.CommandExecutor
+import org.camunda.bpm.engine.variable.VariableMap
+import org.camunda.bpm.engine.variable.Variables
+
+/**
+ * Facility to load variables in a command context.
+ * @param commandExecutor Camunda API executor.
+ * @param taskService Camunda API to access tasks.
+ * @param runtimeService Camunda API to access the execution.
+ */
+class TaskVariableLoader(
+  private val runtimeService: RuntimeService,
+  private val taskService: TaskService,
+  private val commandExecutor: CommandExecutor,
+) {
+  companion object : KLogging()
+
+  /**
+   * Retrieves typed variables from the context of a command.
+   * @param command command context.
+   * @return variable map.
+   */
+  fun <T : TaskIdentity> getTypeVariables(command: T): VariableMap {
+    return if (command.isHistoric()) {
+      // Task updated
+      // This is a historic command which is processed from a command context listener on command context close. Accessing variables at this point will try to add
+      // another command context listener (some camunda feature about updating mutable variables without explicitly saving them), which in turn causes a
+      // ConcurrentModificationException.
+      // We work around this by opening a new context.
+      // Caution: This will only work if the task is already flushed to the database, e.g. if it was created in a previous transaction.
+      // It will also see only the state of the variables that is flushed to the database
+      callInProcessEngineContext(newContext = true) {
+        commandExecutor.execute { innerContext ->
+          val task = taskService.createTaskQuery().taskId(command.id).singleResult()
+          if (task != null) {
+            taskService.getVariablesTyped(command.id)
+          } else {
+            val execution = runtimeService.createExecutionQuery().executionId(command.sourceReference.executionId).singleResult()
+            if (execution != null) {
+              runtimeService.getVariablesTyped(command.sourceReference.executionId)
+            } else {
+              logger.debug { "ENRICHER-004: Could not enrich variables from running execution ${command.sourceReference.executionId}, since it doesn't exist (anymore)." }
+              Variables.createVariables()
+            }
+          }.also {
+            innerContext.registerCommandContextListener(object : CommandContextListener {
+              override fun onCommandContextClose(commandContext: CommandContext) {
+                // Remove all cached entities from the inner context because we don't want to accidentally flush any changes that could cause
+                // OptimisticLockingExceptions in the outer context.
+                // (We don't change any variables but there are situations where _reading_ a variable also causes a change, e.g. when the serialized form of a
+                // complex variable has changed because properties have been added since creation of the variable. Another example: A variable containing a Set
+                // has been created and serialized from a LinkedHashSet with a specific order, but is deserialized to a HashSet with a different iteration order.
+                // When this is serialized again, the serialized form will look different because the order has changed.
+                (commandContext.sessions[DbEntityManager::class.java] as? DbEntityManager)?.dbEntityCache?.apply { cachedEntities.forEach { remove(it) } }
+              }
+
+              override fun onCommandFailed(commandContext: CommandContext, t: Throwable) {
+              }
+            })
+          }
+        }
+      }
+    } else {
+      // Create task
+      taskService.getVariablesTyped(command.id)
+    }
+  }
+}
+
+/**
+ * Checks if the command is created from a historic Camunda event.
+ */
+fun Any.isHistoric(): Boolean =
+  when (this) {
+    is CreateTaskCommand, is DeleteTaskCommand, is CompleteTaskCommand, is AssignTaskCommand, is UpdateAttributeTaskCommand -> false
+    is UpdateAttributesHistoricTaskCommand, is UpdateAssignmentTaskCommand -> true
+    else -> throw IllegalArgumentException("Unexpected command received: '$this'")
+  }
+

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/assigner/EmptyTaskAssigner.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/assigner/EmptyTaskAssigner.kt
@@ -1,11 +1,11 @@
 package io.holunda.polyflow.taskpool.collector.task.assigner
 
-import io.holunda.camunda.taskpool.api.task.TaskIdentity
+import io.holunda.camunda.taskpool.api.task.EngineTaskCommand
 import io.holunda.polyflow.taskpool.collector.task.TaskAssigner
 
 /**
  * No-op task assigner changing nothing.
  */
 class EmptyTaskAssigner : TaskAssigner {
-  override fun <T : TaskIdentity> setAssignment(command: T): T = command
+  override fun setAssignment(command: EngineTaskCommand): EngineTaskCommand = command
 }

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/assigner/EmptyTaskAssigner.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/assigner/EmptyTaskAssigner.kt
@@ -1,0 +1,11 @@
+package io.holunda.polyflow.taskpool.collector.task.assigner
+
+import io.holunda.camunda.taskpool.api.task.TaskIdentity
+import io.holunda.polyflow.taskpool.collector.task.TaskAssigner
+
+/**
+ * No-op task assigner changing nothing.
+ */
+class EmptyTaskAssigner : TaskAssigner {
+  override fun <T : TaskIdentity> setAssignment(command: T): T = command
+}

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/assigner/ProcessVariableChangeAssigningService.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/assigner/ProcessVariableChangeAssigningService.kt
@@ -21,6 +21,9 @@ class ProcessVariableChangeAssigningService(
 
   companion object : KLogging()
 
+  /**
+   * React on new variables created.
+   */
   @EventListener
   fun on(command: CreateSingleProcessVariableCommand): EngineTaskCommand? {
     // only relevant if waiting in a user task
@@ -50,9 +53,35 @@ class ProcessVariableChangeAssigningService(
     }
   }
 
+  /**
+   * React on variables updates.
+   */
   @EventListener
-  fun on(update: UpdateSingleProcessVariableCommand) {
+  fun on(command: UpdateSingleProcessVariableCommand): EngineTaskCommand? {
+    val taskId = getTaskId(command.sourceReference) ?: return null
+    return when (command.variableName) {
+      mapping.assignee -> {
+        AssignTaskCommand(
+          id = taskId,
+          assignee = command.value.value.asStringValue()
+        )
+      }
+      mapping.candidateUsers -> {
+        if (command.value.value != null) {
+          AddCandidateUsersCommand(
+            id = taskId,
+            candidateUsers = command.value.value.asSetValue()
+          )
+        } else {
+          null
+        }
+      }
+      mapping.candidateGroups -> {
+        null
+      }
 
+      else -> null
+    }
   }
 
 

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/assigner/ProcessVariableChangeAssigningService.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/assigner/ProcessVariableChangeAssigningService.kt
@@ -1,0 +1,62 @@
+package io.holunda.polyflow.taskpool.collector.task.assigner
+
+import io.holunda.camunda.taskpool.api.task.*
+import io.holunda.polyflow.taskpool.sender.process.variable.CreateSingleProcessVariableCommand
+import io.holunda.polyflow.taskpool.sender.process.variable.UpdateSingleProcessVariableCommand
+import mu.KLogging
+import org.camunda.bpm.engine.TaskService
+import org.springframework.context.event.EventListener
+
+/**
+ * This service bridges the gap between changes in process variables and change of assignments of existing user tasks.
+ * It subscribes to changes to variables configures as assignment process variables and reacts to those changes
+ * emitting task assignment update events if the underlying process instance is waiting in a user task.
+ *
+ * In order to work properly, the collector needs to activate variable collection (even if the sender is disabled).
+ */
+class ProcessVariableChangeAssigningService(
+  private val taskService: TaskService,
+  private val mapping: ProcessVariableTaskAssignerMapping
+) {
+
+  companion object : KLogging()
+
+  @EventListener
+  fun on(command: CreateSingleProcessVariableCommand): EngineTaskCommand? {
+    // only relevant if waiting in a user task
+    val taskId = getTaskId(command.sourceReference) ?: return null
+    return when (command.variableName) {
+      mapping.assignee -> {
+        AssignTaskCommand(
+          id = taskId,
+          assignee = command.value.value.asStringValue()
+        )
+      }
+      mapping.candidateUsers -> {
+        if (command.value.value != null) {
+          AddCandidateUsersCommand(
+            id = taskId,
+            candidateUsers = command.value.value.asSetValue()
+          )
+        } else {
+          null
+        }
+      }
+      mapping.candidateGroups -> {
+        null
+      }
+
+      else -> null
+    }
+  }
+
+  @EventListener
+  fun on(update: UpdateSingleProcessVariableCommand) {
+
+  }
+
+
+  private fun getTaskId(sourceReference: SourceReference): String? {
+    return taskService.createTaskQuery().executionId(sourceReference.executionId).singleResult()?.id
+  }
+}

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/assigner/ProcessVariableTaskAssignerMapping.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/assigner/ProcessVariableTaskAssignerMapping.kt
@@ -1,0 +1,73 @@
+package io.holunda.polyflow.taskpool.collector.task.assigner
+
+import org.camunda.bpm.engine.variable.VariableMap
+
+/**
+ * A mapping defining the names of process variables used for assignment.
+ */
+data class ProcessVariableTaskAssignerMapping(
+  val assignee: String?,
+  val candidateUsers: String?,
+  val candidateGroups: String?
+) {
+  /**
+   * Loads assignment from variables.
+   */
+  fun loadAssignmentFromVariables(variables: VariableMap): Assignment =
+    Assignment(
+      assignee = if (assignee != null && variables.containsKey(assignee)) {
+        variables[assignee].asStringValue()
+      } else {
+        null
+      },
+      candidateUsers = if (candidateUsers != null && variables.containsKey(candidateUsers)) {
+        variables[candidateUsers].asSetValue()
+      } else {
+        setOf()
+      },
+      candidateGroups = if (candidateGroups != null && variables.containsKey(candidateGroups)) {
+        variables[candidateGroups].asSetValue()
+      } else {
+        setOf()
+      }
+    )
+
+  /**
+   * Assignment information.
+   */
+  data class Assignment(
+    /**
+     * Assignee.
+     */
+    val assignee: String?,
+    /**
+     * Candidate users.
+     */
+    val candidateUsers: Set<String>,
+    /**
+     * Candidate groups.
+     */
+    val candidateGroups: Set<String>
+  )
+}
+
+/**
+ * Variable value to set or empty set.
+ */
+@Suppress("UNCHECKED_CAST")
+fun Any?.asSetValue() =
+  when (this) {
+    is Collection<*> -> (this as Collection<String>).toSet()
+    is String -> this.split(",").map { it.trim() }.toSet()
+    else -> setOf()
+  }
+
+/**
+ * Variable value to string or null.
+ */
+fun Any?.asStringValue() =
+  when (this) {
+    is String -> this
+    else -> null
+  }
+

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/assigner/ProcessVariablesTaskAssigner.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/assigner/ProcessVariablesTaskAssigner.kt
@@ -1,0 +1,44 @@
+package io.holunda.polyflow.taskpool.collector.task.assigner
+
+import io.holunda.camunda.taskpool.api.task.CreateTaskCommand
+import io.holunda.camunda.taskpool.api.task.EngineTaskCommand
+import io.holunda.polyflow.taskpool.collector.task.TaskAssigner
+import io.holunda.polyflow.taskpool.collector.task.TaskVariableLoader
+
+/**
+ * Task assigner retrieving assignment information from process variables.
+ */
+class ProcessVariablesTaskAssigner(
+  private val taskVariableLoader: TaskVariableLoader,
+  private val processVariableTaskAssignerMapping: ProcessVariableTaskAssignerMapping
+) : TaskAssigner {
+  override fun setAssignment(command: EngineTaskCommand): EngineTaskCommand =
+    when (command) {
+      is CreateTaskCommand -> processVariableTaskAssignerMapping
+        .loadAssignmentFromVariables(variables = taskVariableLoader.getTypeVariables(command))
+        .let { assignment ->
+          command.let {
+            if (assignment.assignee != null) {
+              it.copy(assignee = assignment.assignee)
+            } else {
+              it
+            }
+          }.let {
+            if (assignment.candidateUsers.isNotEmpty()) {
+              it.copy(candidateUsers = assignment.candidateUsers)
+            } else {
+              it
+            }
+          }.let {
+            if (assignment.candidateGroups.isNotEmpty()) {
+              it.copy(candidateGroups = assignment.candidateGroups)
+            } else {
+              it
+            }
+          }
+        }
+
+      else -> command
+    }
+
+}

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/enricher/ProcessVariableFilter.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/enricher/ProcessVariableFilter.kt
@@ -6,12 +6,12 @@ package io.holunda.polyflow.taskpool.collector.task.enricher
  * If a differentiation between individual user tasks of a process is required, use a {@link TaskVariableFilter} instead.
  */
 data class ProcessVariableFilter(
-        override val processDefinitionKey: ProcessDefinitionKey?,
-        val filterType: FilterType,
-        val processVariables: List<VariableName> = emptyList()
-): VariableFilter {
+  override val processDefinitionKey: ProcessDefinitionKey?,
+  val filterType: FilterType,
+  val processVariables: List<VariableName> = emptyList()
+) : VariableFilter {
 
-  constructor(filterType: FilterType, processVariables: List<VariableName>): this(null, filterType, processVariables)
+  constructor(filterType: FilterType, processVariables: List<VariableName>) : this(null, filterType, processVariables)
 
   override fun filter(taskDefinitionKey: TaskDefinitionKey, variableName: VariableName): Boolean {
     return (filterType == FilterType.INCLUDE) == processVariables.contains(variableName)

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/enricher/ProcessVariablesTaskCommandEnricher.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/enricher/ProcessVariablesTaskCommandEnricher.kt
@@ -2,6 +2,7 @@ package io.holunda.polyflow.taskpool.collector.task.enricher
 
 import io.holunda.camunda.taskpool.api.task.*
 import io.holunda.polyflow.taskpool.callInProcessEngineContext
+import io.holunda.polyflow.taskpool.collector.task.TaskVariableLoader
 import io.holunda.polyflow.taskpool.collector.task.VariablesEnricher
 import io.holunda.polyflow.taskpool.putAllTyped
 import mu.KLogging
@@ -16,76 +17,21 @@ import org.camunda.bpm.engine.variable.Variables.createVariables
 
 /**
  * Enriches commands with process variables.
- * @param runtimeService Camunda API to access the execution.
  * @param processVariablesFilter filter to whitelist or blacklist the variables which should be added to the task.
  */
 open class ProcessVariablesTaskCommandEnricher(
-  private val runtimeService: RuntimeService,
-  private val taskService: TaskService,
-  private val commandExecutor: CommandExecutor,
   private val processVariablesFilter: ProcessVariablesFilter,
   private val processVariablesCorrelator: ProcessVariablesCorrelator,
+  private val taskVariableLoader: TaskVariableLoader
 ) : VariablesEnricher {
 
   companion object : KLogging()
 
 
-  /**
-   * Retrieves typed variables to enrich current command.
-   * @param command command to enrich.
-   * @return variable map.
-   */
-  open fun <T : TaskIdentityWithPayloadAndCorrelations> getTypeVariables(command: T): VariableMap {
-    return if (command.isHistoric()) {
-      // Task updated
-      // This is a historic command which is processed from a command context listener on command context close. Accessing variables at this point will try to add
-      // another command context listener (some camunda feature about updating mutable variables without explicitly saving them), which in turn causes a
-      // ConcurrentModificationException.
-      // We work around this by opening a new context.
-      // Caution: This will only work if the task is already flushed to the database, e.g. if it was created in a previous transaction.
-      // It will also see only the state of the variables that is flushed to the database
-      callInProcessEngineContext(newContext = true) {
-        commandExecutor.execute { innerContext ->
-          val task = taskService.createTaskQuery().taskId(command.id).singleResult()
-          if (task != null) {
-            taskService.getVariablesTyped(command.id)
-          } else {
-            val execution = runtimeService.createExecutionQuery().executionId(command.sourceReference.executionId).singleResult()
-            if (execution != null) {
-              runtimeService.getVariablesTyped(command.sourceReference.executionId)
-            } else {
-              logger.debug { "ENRICHER-004: Could not enrich variables from running execution ${command.sourceReference.executionId}, since it doesn't exist (anymore)." }
-              createVariables()
-            }
-          }
-            .also {
-              innerContext.registerCommandContextListener(object : CommandContextListener {
-                override fun onCommandContextClose(commandContext: CommandContext) {
-                  // Remove all cached entities from the inner context because we don't want to accidentally flush any changes that could cause
-                  // OptimisticLockingExceptions in the outer context.
-                  // (We don't change any variables but there are situations where _reading_ a variable also causes a change, e.g. when the serialized form of a
-                  // complex variable has changed because properties have been added since creation of the variable. Another example: A variable containing a Set
-                  // has been created and serialized from a LinkedHashSet with a specific order, but is deserialized to a HashSet with a different iteration order.
-                  // When this is serialized again, the serialized form will look different because the order has changed.
-                  (commandContext.sessions[DbEntityManager::class.java] as? DbEntityManager)?.dbEntityCache?.apply { cachedEntities.forEach { remove(it) } }
-                }
-
-                override fun onCommandFailed(commandContext: CommandContext, t: Throwable) {
-                }
-              })
-            }
-        }
-      }
-    } else {
-      // Create task
-      taskService.getVariablesTyped(command.id)
-    }
-  }
-
   override fun <T : TaskIdentityWithPayloadAndCorrelations> enrich(command: T): T {
 
     // load variables typed
-    val variablesTyped = getTypeVariables(command)
+    val variablesTyped = taskVariableLoader.getTypeVariables(command)
 
     // Payload enrichment
     command.payload.putAllTyped(
@@ -110,18 +56,4 @@ open class ProcessVariablesTaskCommandEnricher(
     return command
   }
 }
-
-/**
- * Checks if the command is created from a historic Camunda event.
- */
-fun Any.isHistoric(): Boolean =
-  when (this) {
-    is CreateTaskCommand, is DeleteTaskCommand, is CompleteTaskCommand, is AssignTaskCommand, is UpdateAttributeTaskCommand -> false
-    is UpdateAttributesHistoricTaskCommand, is UpdateAssignmentTaskCommand -> true
-    else -> throw IllegalArgumentException("Unexpected command received: '$this'")
-  }
-
-
-
-
 

--- a/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/enricher/VariableFilter.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/main/kotlin/io/holunda/polyflow/taskpool/collector/task/enricher/VariableFilter.kt
@@ -8,7 +8,7 @@ interface VariableFilter {
   val processDefinitionKey: ProcessDefinitionKey?
 
   /**
-   * Returns whether or not the process variable with the given name shall be contained in the payload of the given task.
+   * Returns whether the process variable with the given name shall be contained in the payload of the given task.
    * @param taskDefinitionKey the key of the task to be enriched
    * @param variableName the name of the process variable
    */

--- a/integration/camunda-bpm/taskpool-collector/src/test/kotlin/io/holunda/polyflow/taskpool/collector/properties/CamundaTaskpoolCollectorPropertiesExtendedTest.kt
+++ b/integration/camunda-bpm/taskpool-collector/src/test/kotlin/io/holunda/polyflow/taskpool/collector/properties/CamundaTaskpoolCollectorPropertiesExtendedTest.kt
@@ -4,6 +4,7 @@ import com.thoughtworks.xstream.XStream
 import io.holunda.polyflow.taskpool.collector.CamundaTaskpoolCollectorConfiguration
 import io.holunda.polyflow.taskpool.collector.CamundaTaskpoolCollectorProperties
 import io.holunda.polyflow.taskpool.collector.TaskCollectorEnricherType
+import io.holunda.polyflow.taskpool.collector.task.TaskVariableLoader
 import io.holunda.polyflow.taskpool.collector.task.VariablesEnricher
 import io.holunda.polyflow.taskpool.sender.process.definition.ProcessDefinitionCommandSender
 import io.holunda.polyflow.taskpool.sender.process.instance.ProcessInstanceCommandSender
@@ -15,6 +16,9 @@ import org.axonframework.eventhandling.EventBus
 import org.axonframework.serialization.Serializer
 import org.axonframework.serialization.xml.XStreamSerializer
 import org.camunda.bpm.engine.RepositoryService
+import org.camunda.bpm.engine.RuntimeService
+import org.camunda.bpm.engine.TaskService
+import org.camunda.bpm.engine.impl.interceptor.CommandExecutor
 import org.camunda.bpm.spring.boot.starter.property.CamundaBpmProperties
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -85,6 +89,7 @@ internal class CamundaTaskpoolCollectorPropertiesExtendedTest {
   private class AdditionalMockConfiguration {
     @Bean
     fun variablesEnricher(): VariablesEnricher = mock(VariablesEnricher::class.java)
+
   }
 
   /**
@@ -118,5 +123,14 @@ internal class CamundaTaskpoolCollectorPropertiesExtendedTest {
 
     @Bean
     fun repositoryService(): RepositoryService = mock()
+
+    @Bean
+    fun runtimeService(): RuntimeService = mock()
+
+    @Bean
+    fun taskService(): TaskService = mock()
+
+    @Bean
+    fun commandExecutor(): CommandExecutor = mock()
   }
 }

--- a/view/jpa/pom.xml
+++ b/view/jpa/pom.xml
@@ -103,6 +103,12 @@
       <groupId>org.axonframework</groupId>
       <artifactId>axon-spring-boot-starter</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.axonframework</groupId>
+          <artifactId>axon-server-connector</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/view/jpa/pom.xml
+++ b/view/jpa/pom.xml
@@ -51,7 +51,6 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.200</version> <!-- pin -->
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/task/TaskRepository.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/task/TaskRepository.kt
@@ -27,6 +27,17 @@ interface TaskRepository : CrudRepository<TaskEntity, String>, JpaSpecificationE
           builder.isNull(task.get<String>(TaskEntity::assignee.name))
         }
       }
+
+    /**
+     * Is assignee set to specified user.
+     */
+    fun isAssignedTo(assignee: String): Specification<TaskEntity> =
+      Specification { task, _, builder ->
+        builder.equal(
+          task.get<String>(TaskEntity::assignee.name),
+          assignee
+        )
+      }
     /**
      * Specification for checking authorization of multiple principals.
      */

--- a/view/jpa/src/sql/persistence.xml
+++ b/view/jpa/src/sql/persistence.xml
@@ -1,8 +1,8 @@
 <persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence" version="2.1">
   <persistence-unit name="default">
 
+    <!-- Uncomment this to generate the SQL for Axon Framework entities -->
     <!--
-    Uncomment this to generate the SQL for Axon Framework entities
     <class>org.axonframework.eventsourcing.eventstore.jpa.DomainEventEntry</class>
     <class>org.axonframework.eventsourcing.eventstore.jpa.SnapshotEventEntry</class>
     <class>org.axonframework.modelling.saga.repository.jpa.SagaEntry</class>

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceDataEntryITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceDataEntryITest.kt
@@ -39,7 +39,6 @@ import java.time.temporal.ChronoUnit
 import java.util.*
 import java.util.function.Predicate
 
-@ExtendWith(SpringExtension::class)
 @SpringBootTest(
   classes = [TestApplication::class],
   properties = [

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceDataEntryRevisionSupportITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceDataEntryRevisionSupportITest.kt
@@ -39,7 +39,6 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import javax.transaction.Transactional
 
-@ExtendWith(SpringExtension::class)
 @SpringBootTest(
   classes = [TestApplication::class],
   properties = [

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceProcessDefinitionITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceProcessDefinitionITest.kt
@@ -16,7 +16,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.util.*
 import javax.transaction.Transactional
 
-@ExtendWith(SpringExtension::class)
 @SpringBootTest(
   classes = [TestApplication::class],
   properties = [

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceProcessInstanceITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceProcessInstanceITest.kt
@@ -19,7 +19,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.util.*
 import javax.transaction.Transactional
 
-@ExtendWith(SpringExtension::class)
 @SpringBootTest(
   classes = [TestApplication::class],
   properties = [

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceTaskITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceTaskITest.kt
@@ -38,7 +38,6 @@ import java.time.ZoneOffset
 import java.util.*
 import java.util.function.Predicate
 
-@ExtendWith(SpringExtension::class)
 @SpringBootTest(
   classes = [TestApplication::class],
   properties = [

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/data/DataEntryRepositoryITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/data/DataEntryRepositoryITest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.data.jpa.domain.Specification.where
 import org.springframework.data.repository.findByIdOrNull
@@ -30,11 +31,11 @@ import java.util.*
 import javax.persistence.EntityManager
 import javax.transaction.Transactional
 
-@ExtendWith(SpringExtension::class)
 @DataJpaTest(showSql = false)
 @Transactional
 @DirtiesContext
 @ContextConfiguration(classes = [TestApplication::class])
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("itest", "mock-query-emitter")
 internal class DataEntryRepositoryITest {
   @Autowired

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/itest/FixedH2Dialect.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/itest/FixedH2Dialect.kt
@@ -1,0 +1,13 @@
+package io.holunda.polyflow.view.jpa.itest
+
+import org.hibernate.dialect.H2Dialect
+import java.sql.Types
+
+class FixedH2Dialect : H2Dialect() {
+  init {
+    // registerColumnType(Types.VARBINARY, "bytea")
+    registerColumnType(Types.BLOB, "bytea")
+    // registerColumnType(Types.LONGVARBINARY, "bytea");
+  }
+
+}

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/process/ProcessDefinitionRepositoryITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/process/ProcessDefinitionRepositoryITest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
@@ -16,9 +17,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.util.*
 import javax.persistence.EntityManager
 
-@ExtendWith(SpringExtension::class)
 @DataJpaTest(showSql = false)
 @ContextConfiguration(classes = [TestApplicationDataJpa::class])
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("itest", "mock-query-emitter")
 class ProcessDefinitionRepositoryITest {
   @Autowired

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/process/ProcessInstanceRepositoryITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/process/ProcessInstanceRepositoryITest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
@@ -16,9 +17,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.util.*
 import javax.persistence.EntityManager
 
-@ExtendWith(SpringExtension::class)
 @DataJpaTest(showSql = false)
 @ContextConfiguration(classes = [TestApplicationDataJpa::class])
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("itest", "mock-query-emitter")
 class ProcessInstanceRepositoryITest {
   @Autowired

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/task/TaskRepositoryITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/task/TaskRepositoryITest.kt
@@ -19,19 +19,17 @@ import org.camunda.bpm.engine.variable.Variables.createVariables
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
-import org.springframework.test.context.junit.jupiter.SpringExtension
-import org.springframework.transaction.annotation.Transactional
 import java.util.*
 import javax.persistence.EntityManager
 
-@ExtendWith(SpringExtension::class)
 @DataJpaTest(showSql = false)
 @ContextConfiguration(classes = [TestApplicationDataJpa::class])
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("itest", "mock-query-emitter")
 class TaskRepositoryITest {
   @Autowired

--- a/view/jpa/src/test/resources/application-itest.yaml
+++ b/view/jpa/src/test/resources/application-itest.yaml
@@ -2,9 +2,17 @@ spring:
   jpa:
     open-in-view: true # disable JPA warning
     show-sql: false
-    database-platform: org.hibernate.dialect.H2Dialect
+    database-platform: io.holunda.polyflow.view.jpa.itest.FixedH2Dialect
+    generate-ddl: true
+    hibernate.ddl-auto: create-drop
   datasource:
-    driverClassName: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;INIT=create schema if not exists PUBLIC;DB_CLOSE_DELAY=-1;NON_KEYWORDS=VALUE;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password: sa
+    hikari:
+      connection-test-query: select 1 from dual;
+      schema: PUBLIC
+    driver-class-name: org.h2.Driver
 
 polyflow:
   view:
@@ -13,11 +21,12 @@ polyflow:
 
 logging:
   level:
+    root: INFO
     org.springframework: INFO
     org.axonframework: INFO
     org.hibernate.type: INFO # activate this and generic ROOT logger to see SQL and binding
-    io.holixon.axon.gateway.query: DEBUG
-    io.holunda.polyflow.view.jpa: DEBUG
+    io.holixon.axon.gateway.query: INFO
+    io.holunda.polyflow.view.jpa: INFO
 
 axon:
   axonserver:


### PR DESCRIPTION
Apart from default task assignment, use process variables to manage assignee, candidate users and candidate groups.

Fix #738