### PR TITLE
Feature/847 support multiple sort criterias

### DIFF
--- a/docs/reference-guide/components/view-api.md
+++ b/docs/reference-guide/components/view-api.md
@@ -105,7 +105,7 @@ interface PageableSortableQuery {
 The `page` parameter denotes the page number to deliver (starting with `0`). The `size` parameter denotes the number of elements on a page. By default, the `page` is set to `0`
 and the size is set to `Int.MAX`. 
 
-An optional `sort` parameter allows to sort the results by a field attribute. The format of the `sort` string is `<+|->fieldName`, `+fieldName` means sort by `fieldName` ascending,
+An optional `sort` list allows to sort the results by multiple field attributes. The format of the `sort` string is `<+|->fieldName`, `+fieldName` means sort by `fieldName` ascending,
 `-fieldName` means sort by `fieldName` descending. The field must be a direct member of the result (`Task` for queries on `Task` and `TaskWithDataEntries` or `DataEntry`) and must be one of the following type:
 
 * java.lang.Integer

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewDataEntryService.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewDataEntryService.kt
@@ -200,7 +200,7 @@ class JpaPolyflowViewDataEntryService(
   }
 
   private fun reportMissingFeature(query: PageableSortableQuery) {
-    if (query.sort != null) {
+    if (query.sort.isEmpty()) {
       logger.warn { "Sorting is currently not supported, but the sort was requested: ${query.sort}, see https://github.com/holunda-io/camunda-bpm-taskpool/issues/701" }
     }
   }

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewTaskService.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewTaskService.kt
@@ -537,7 +537,7 @@ class JpaPolyflowViewTaskService(
   }
 
   private fun reportMissingFeature(query: PageableSortableQuery) {
-    if (query.sort != null) {
+    if (query.sort.isEmpty()) {
       logger.warn { "Sorting is currently not supported, but the sort was requested: ${query.sort}, see https://github.com/holunda-io/camunda-bpm-taskpool/issues/701" }
     }
     if (query.page != 1 || query.size != Int.MAX_VALUE) {

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/SpecificationExt.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/SpecificationExt.kt
@@ -122,8 +122,8 @@ fun PageableSortableQuery.mapTaskSort(): List<String> {
     listOf("-${TaskEntity::createdDate.name}")
   } else {
     sort.map {
-      val direction = it!!.substring(0,1)
-      val field = it!!.substring(1)
+      val direction = it.substring(0,1)
+      val field = it.substring(1)
       when (field) {
         Task::name.name -> TaskEntity::name.name
         Task::description.name -> TaskEntity::description.name

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/SpecificationExt.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/SpecificationExt.kt
@@ -93,7 +93,13 @@ fun pageRequest(page: Int, size: Int, sort: String?): PageRequest {
   }
 }
 
-fun pageRequest(page: Int, size: Int, sort: List<String>): PageRequest {
+/**
+ * Constructs page request.
+ * @param page page number.
+ * @param size page size
+ * @param sort optional sort, where each element in format +filedName or -fieldName
+ */
+fun pageRequest(page: Int, size: Int, sort: List<String> = listOf()): PageRequest {
   val sortCriteria = sort.map { s ->
     val direction = if (s.substring(0, 1) == "+") {
       Direction.ASC

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/SpecificationExt.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/SpecificationExt.kt
@@ -32,6 +32,7 @@ import io.holunda.polyflow.view.query.PageableSortableQuery
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.data.domain.Sort.Direction
+import org.springframework.data.domain.Sort.Order
 import org.springframework.data.jpa.domain.Specification
 import org.springframework.data.jpa.domain.Specification.where
 import java.time.Instant
@@ -92,32 +93,48 @@ fun pageRequest(page: Int, size: Int, sort: String?): PageRequest {
   }
 }
 
+fun pageRequest(page: Int, size: Int, sort: List<String>): PageRequest {
+  val sortCriteria = sort.map { s ->
+    val direction = if (s.substring(0, 1) == "+") {
+      Direction.ASC
+    } else {
+      Direction.DESC
+    }
+    Order.by(s.substring(1)).with(direction)
+  }.toList()
+
+
+    return PageRequest.of(page, size, Sort.by(sortCriteria))
+}
+
 /**
  * Map sort string from the view API to implementation sort of the entities.
  */
-fun PageableSortableQuery.mapTaskSort(): String {
-  return if (this.sort == null) {
+fun PageableSortableQuery.mapTaskSort(): List<String> {
+  return if (this.sort.isEmpty()) {
     // no sort is specified, we don't want unsorted results.
-    "-${TaskEntity::createdDate.name}"
+    listOf("-${TaskEntity::createdDate.name}")
   } else {
-    val direction = sort!!.substring(0, 1)
-    val field = sort!!.substring(1)
-    return when (field) {
-      Task::name.name -> TaskEntity::name.name
-      Task::description.name -> TaskEntity::description.name
-      Task::assignee.name -> TaskEntity::assignee.name
-      Task::createTime.name -> TaskEntity::createdDate.name
-      Task::dueDate.name -> TaskEntity::dueDate.name
-      Task::followUpDate.name -> TaskEntity::followUpDate.name
-      Task::owner.name -> TaskEntity::owner.name
-      Task::priority.name -> TaskEntity::priority.name
-      Task::formKey.name -> TaskEntity::formKey.name
-      Task::businessKey.name -> TaskEntity::businessKey.name
-      Task::id.name -> TaskEntity::taskId.name
-      Task::taskDefinitionKey.name -> TaskEntity::taskDefinitionKey.name
-      else -> throw IllegalArgumentException("'$field' is not supported for sorting in JPA View")
-    }.let { "$direction$it" }
-  }
+    sort.map {
+      val direction = it!!.substring(0,1)
+      val field = it!!.substring(1)
+      when (field) {
+        Task::name.name -> TaskEntity::name.name
+        Task::description.name -> TaskEntity::description.name
+        Task::assignee.name -> TaskEntity::assignee.name
+        Task::createTime.name -> TaskEntity::createdDate.name
+        Task::dueDate.name -> TaskEntity::dueDate.name
+        Task::followUpDate.name -> TaskEntity::followUpDate.name
+        Task::owner.name -> TaskEntity::owner.name
+        Task::priority.name -> TaskEntity::priority.name
+        Task::formKey.name -> TaskEntity::formKey.name
+        Task::businessKey.name -> TaskEntity::businessKey.name
+        Task::id.name -> TaskEntity::taskId.name
+        Task::taskDefinitionKey.name -> TaskEntity::taskDefinitionKey.name
+        else -> throw IllegalArgumentException("'$field' is not supported for sorting in JPA View")
+      }.let { "$direction$it" }
+      }
+    }
 }
 
 

--- a/view/mongo/src/main/kotlin/io/holunda/polyflow/view/mongo/MongoViewService.kt
+++ b/view/mongo/src/main/kotlin/io/holunda/polyflow/view/mongo/MongoViewService.kt
@@ -506,3 +506,13 @@ internal fun sort(sort: String?): Sort =
   } else {
     Sort.unsorted()
   }
+
+internal fun sort(sort: List<String>): Sort {
+  return if (sort.isNotEmpty()) {
+    val combinedSort = sort.map { sort(it) }.filter { it.isSorted }
+    if (combinedSort.isEmpty()) Sort.unsorted()
+    else combinedSort.reduce { combined, element -> combined.and(element) }
+  } else {
+    Sort.unsorted()
+  }
+}

--- a/view/mongo/src/test/kotlin/io/holunda/polyflow/view/mongo/service/PolyflowMongoServiceSortTest.kt
+++ b/view/mongo/src/test/kotlin/io/holunda/polyflow/view/mongo/service/PolyflowMongoServiceSortTest.kt
@@ -9,6 +9,7 @@ class PolyflowMongoServiceSortTest {
 
   @Test
   fun `should be unsorted for null, empty or wrong sort`() {
+    assertThat(sort(listOf())).isEqualTo(Sort.unsorted())
     assertThat(sort(null)).isEqualTo(Sort.unsorted())
     assertThat(sort("")).isEqualTo(Sort.unsorted())
     assertThat(sort("foo")).isEqualTo(Sort.unsorted())
@@ -20,5 +21,13 @@ class PolyflowMongoServiceSortTest {
     assertThat(sort("-bar")).isEqualTo(Sort.by(Sort.Direction.DESC, "bar"))
     assertThat(sort("-b")).isEqualTo(Sort.by(Sort.Direction.DESC, "b"))
   }
+
+  @Test
+  fun `should combine sort`() {
+    assertThat(sort(listOf("+foo", "-bar"))).isEqualTo(Sort.by(Sort.Direction.ASC, "foo").and(Sort.by(Sort.Direction.DESC, "bar")))
+    assertThat(sort(listOf("+foo", ""))).isEqualTo(Sort.by(Sort.Direction.ASC, "foo"))
+    assertThat(sort(listOf("", "foo"))).isEqualTo(Sort.unsorted())
+  }
+
 
 }

--- a/view/simple/src/test/kotlin/io/holunda/polyflow/view/simple/service/SimpleTaskPoolServiceTest.kt
+++ b/view/simple/src/test/kotlin/io/holunda/polyflow/view/simple/service/SimpleTaskPoolServiceTest.kt
@@ -278,6 +278,18 @@ class SimpleTaskPoolServiceTest : ScenarioTest<SimpleTaskPoolGivenStage<*>, Simp
       .tasks_are_returned(listOf(then().tasks[5]))
   }
 
+  @Test
+  fun `retrieves all task sort by multiple values`() {
+    given()
+      .tasks_exist(5)
+
+    `when`()
+      .all_tasks_are_queried(filters = listOf(), sort = listOf("+task.dueDate", "-task.businessKey"))
+
+    then()
+      .all_task_are_returned_and_sorted_by(reversed = true) { it.task.businessKey }
+  }
+
   private infix fun String.withTaskCount(taskCount: Int) = ApplicationWithTaskCount(this, taskCount)
 }
 

--- a/view/view-api/src/main/kotlin/query/PageableSortableQuery.kt
+++ b/view/view-api/src/main/kotlin/query/PageableSortableQuery.kt
@@ -30,12 +30,12 @@ interface PageableSortableQuery {
     }
     sort.forEach {
 
-      val direction = it!!.substring(0, 1)
+      val direction = it.substring(0, 1)
       require(
         direction == ASCENDING.sign
           || direction == DESCENDING.sign
       ) { "Sort must start either with '${ASCENDING.sign}' or '${DESCENDING.sign}' but it was starting with '$direction'" }
-      val parameter = it!!.substring(1)
+      val parameter = it.substring(1)
       require(fieldNames.contains(parameter)) {
         "Sort parameter must be one of ${
           fieldNames.joinToString(", ")

--- a/view/view-api/src/main/kotlin/query/PageableSortableQuery.kt
+++ b/view/view-api/src/main/kotlin/query/PageableSortableQuery.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.full.declaredMemberProperties
 interface PageableSortableQuery {
   val page: Int
   val size: Int
-  val sort: String?
+  val sort: List<String>
 
   /**
    * Checks that the sort parameter is correctly specified.
@@ -25,19 +25,22 @@ interface PageableSortableQuery {
    * Checks that the sort parameter is correctly specified.
    */
   fun sanitizeSort(fieldNames: Set<String>) {
-    if (sort == null) {
+    if (sort.isEmpty()) {
       return
     }
-    val direction = sort!!.substring(0, 1)
-    require(
-      direction == ASCENDING.sign
-        || direction == DESCENDING.sign
-    ) { "Sort must start either with '${ASCENDING.sign}' or '${DESCENDING.sign}' but it was starting with '$direction'" }
-    val parameter = sort!!.substring(1)
-    require(fieldNames.contains(parameter)) {
-      "Sort parameter must be one of ${
-        fieldNames.joinToString(", ")
-      } but it was $parameter."
+    sort.forEach {
+
+      val direction = it!!.substring(0, 1)
+      require(
+        direction == ASCENDING.sign
+          || direction == DESCENDING.sign
+      ) { "Sort must start either with '${ASCENDING.sign}' or '${DESCENDING.sign}' but it was starting with '$direction'" }
+      val parameter = it!!.substring(1)
+      require(fieldNames.contains(parameter)) {
+        "Sort parameter must be one of ${
+          fieldNames.joinToString(", ")
+        } but it was $parameter."
+      }
     }
   }
 

--- a/view/view-api/src/main/kotlin/query/data/DataEntriesForDataEntryTypeQuery.kt
+++ b/view/view-api/src/main/kotlin/query/data/DataEntriesForDataEntryTypeQuery.kt
@@ -15,8 +15,16 @@ data class DataEntriesForDataEntryTypeQuery(
   val entryType: EntryType,
   override val page: Int = 0,
   override val size: Int = Int.MAX_VALUE,
-  override val sort: String? = null
+  override val sort: List<String> = listOf()
 ) : FilterQuery<DataEntry>, PageableSortableQuery {
+
+  @Deprecated("Please use other constructor setting sort as List<String>")
+  constructor(entryType: EntryType, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String): this(
+    entryType = entryType,
+    page = page,
+    size = size,
+    sort = listOf(sort),
+  )
 
   override fun applyFilter(element: DataEntry) = element.entryType == this.entryType
 }

--- a/view/view-api/src/main/kotlin/query/data/DataEntriesForUserQuery.kt
+++ b/view/view-api/src/main/kotlin/query/data/DataEntriesForUserQuery.kt
@@ -20,10 +20,19 @@ data class DataEntriesForUserQuery(
   val user: User,
   override val page: Int = 0,
   override val size: Int = Int.MAX_VALUE,
-  override val sort: String? = null,
+  override val sort: List<String> = listOf(),
   val filters: List<String> = listOf()
 
 ) : FilterQuery<DataEntry>, PageableSortableQuery {
+
+  @Deprecated("Please use other constructor setting sort as List<String>")
+  constructor(user: User, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
+    user = user,
+    page = page,
+    size = size,
+    sort = listOf(sort),
+    filters = filters
+  )
 
   // jackson serialization works because delegate property is private
   private val predicates by lazy { createDataEntryPredicates(toCriteria(filters)) }

--- a/view/view-api/src/main/kotlin/query/data/DataEntriesQuery.kt
+++ b/view/view-api/src/main/kotlin/query/data/DataEntriesQuery.kt
@@ -1,6 +1,7 @@
 package io.holunda.polyflow.view.query.data
 
 import io.holunda.polyflow.view.DataEntry
+import io.holunda.polyflow.view.auth.User
 import io.holunda.polyflow.view.filter.createDataEntryPredicates
 import io.holunda.polyflow.view.filter.filterByPredicate
 import io.holunda.polyflow.view.filter.toCriteria
@@ -17,9 +18,17 @@ import io.holunda.polyflow.view.query.PageableSortableQuery
 data class DataEntriesQuery(
   override val page: Int = 0,
   override val size: Int = Int.MAX_VALUE,
-  override val sort: String? = null,
+  override val sort: List<String> = listOf(),
   val filters: List<String> = listOf()
 ) : FilterQuery<DataEntry>, PageableSortableQuery {
+
+  @Deprecated("Please use other constructor setting sort as List<String>")
+  constructor(page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
+    page = page,
+    size = size,
+    sort = listOf(sort),
+    filters = filters
+  )
 
   // jackson serialization works because delegate property is private
   private val predicates by lazy { createDataEntryPredicates(toCriteria(filters)) }

--- a/view/view-api/src/main/kotlin/query/task/AllTasksQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/AllTasksQuery.kt
@@ -14,9 +14,18 @@ import io.holunda.polyflow.view.query.PageableSortableQuery
 data class AllTasksQuery(
   override val page: Int = 0,
   override val size: Int = Int.MAX_VALUE,
-  override val sort: String? = null,
+  override val sort: List<String> = listOf(),
   override val filters: List<String> = listOf()
 ) : PageableSortableFilteredTaskQuery {
+
+  @Deprecated("Please use other constructor setting sort as List<String>")
+  constructor(page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
+    page = page,
+    size = size,
+    sort = listOf(sort),
+    filters = filters
+  )
+
   override fun applyFilter(element: Task): Boolean = true
 }
 

--- a/view/view-api/src/main/kotlin/query/task/AllTasksWithDataEntriesQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/AllTasksWithDataEntriesQuery.kt
@@ -1,6 +1,7 @@
 package io.holunda.polyflow.view.query.task
 
 import io.holunda.polyflow.view.TaskWithDataEntries
+import io.holunda.polyflow.view.auth.User
 import io.holunda.polyflow.view.query.FilterQuery
 import io.holunda.polyflow.view.query.PageableSortableQuery
 
@@ -14,9 +15,18 @@ import io.holunda.polyflow.view.query.PageableSortableQuery
 data class AllTasksWithDataEntriesQuery(
   override val page: Int = 0,
   override val size: Int = Int.MAX_VALUE,
-  override val sort: String? = null,
+  override val sort: List<String> = listOf(),
   val filters: List<String> = listOf()
 ) : FilterQuery<TaskWithDataEntries>, PageableSortableQuery {
+
+  @Deprecated("Please use other constructor setting sort as List<String>")
+  constructor(page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
+    page = page,
+    size = size,
+    sort = listOf(sort),
+    filters = filters
+  )
+
   override fun applyFilter(element: TaskWithDataEntries): Boolean = AllTasksQuery(page, size, sort, filters).applyFilter(element.task)
 }
 

--- a/view/view-api/src/main/kotlin/query/task/TasksForCandidateUserAndGroupQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksForCandidateUserAndGroupQuery.kt
@@ -17,9 +17,19 @@ data class TasksForCandidateUserAndGroupQuery(
   val includeAssigned: Boolean = true,
   override val page: Int = 0,
   override val size: Int = Int.MAX_VALUE,
-  override val sort: String? = null,
+  override val sort: List<String> = listOf(),
   override val filters: List<String> = listOf()
 ) : PageableSortableFilteredTaskQuery {
+
+  @Deprecated("Please use other constructor setting sort as List<String>")
+  constructor(user: User, includeAssigned: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
+    user = user,
+    includeAssigned = includeAssigned,
+    page = page,
+    size = size,
+    sort = listOf(sort),
+    filters = filters
+  )
 
   override fun applyFilter(element: Task): Boolean =
     (element.candidateGroups.any { candidateGroup -> this.user.groups.contains(candidateGroup) }

--- a/view/view-api/src/main/kotlin/query/task/TasksForGroupQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksForGroupQuery.kt
@@ -19,9 +19,19 @@ data class TasksForGroupQuery(
   val includeAssigned: Boolean = false,
   override val page: Int = 0,
   override val size: Int = Int.MAX_VALUE,
-  override val sort: String? = null,
+  override val sort: List<String> = listOf(),
   override val filters: List<String> = listOf()
 ) : PageableSortableFilteredTaskQuery {
+
+  @Deprecated("Please use other constructor setting sort as List<String>")
+  constructor(user: User, includeAssigned: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
+    user = user,
+    includeAssigned = includeAssigned,
+    page = page,
+    size = size,
+    sort = listOf(sort),
+    filters = filters
+  )
 
   override fun applyFilter(element: Task): Boolean =
     element.candidateGroups.any { candidateGroup -> this.user.groups.contains(candidateGroup) }

--- a/view/view-api/src/main/kotlin/query/task/TasksForUserQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksForUserQuery.kt
@@ -17,15 +17,25 @@ data class TasksForUserQuery(
   val assignedToMeOnly: Boolean = false,
   override val page: Int = 0,
   override val size: Int = Int.MAX_VALUE,
-  override val sort: String? = null,
+  override val sort: List<String> = listOf(),
   override val filters: List<String> = listOf()
 ) : PageableSortableFilteredTaskQuery {
+
+  @Deprecated("Please use other constructor setting sort as List<String>")
+  constructor(user: User, assignedToMeOnly: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
+    user = user,
+    assignedToMeOnly = assignedToMeOnly,
+    page = page,
+    size = size,
+    sort = listOf(sort),
+    filters = filters
+  )
 
   /**
    * Compatibility constructor for old clients.
    */
   @Deprecated(message = "Please use other constructor setting the assignedToMeOnly.")
-  constructor(user: User, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String? = null, filters: List<String> = listOf()): this(
+  constructor(user: User, page: Int = 0, size: Int = Int.MAX_VALUE, sort: List<String> = listOf(), filters: List<String> = listOf()): this(
     user = user,
     assignedToMeOnly = false,
     page = page,

--- a/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForGroupQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForGroupQuery.kt
@@ -19,9 +19,14 @@ data class TasksWithDataEntriesForGroupQuery(
   val includeAssigned: Boolean = false,
   override val page: Int = 0,
   override val size: Int = Int.MAX_VALUE,
-  override val sort: String? = null,
+  override val sort: List<String> = listOf(),
   val filters: List<String> = listOf()
 ) : FilterQuery<TaskWithDataEntries>, PageableSortableQuery {
+
+  @Deprecated("Please use other constructor setting sort as List<String>")
+  constructor(user: User, includeAssigned: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()) : this(
+    user = user, includeAssigned = includeAssigned, page = page, size = size, sort = listOf(sort), filters = filters
+  )
 
   override fun applyFilter(element: TaskWithDataEntries): Boolean =
     TasksForGroupQuery(user, includeAssigned, page, size, sort, filters).applyFilter(element.task)

--- a/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForUserQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForUserQuery.kt
@@ -19,15 +19,20 @@ data class TasksWithDataEntriesForUserQuery(
   val assignedToMeOnly: Boolean = false,
   override val page: Int = 0,
   override val size: Int = Int.MAX_VALUE,
-  override val sort: String? = null,
+  override val sort: List<String> = listOf(),
   val filters: List<String> = listOf()
 ) : FilterQuery<TaskWithDataEntries>, PageableSortableQuery {
+
+  @Deprecated("Please use other constructor setting sort as List<String>")
+  constructor(user: User, assignedToMeOnly: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()) : this(
+    user = user, assignedToMeOnly = assignedToMeOnly, page = page, size = size, sort = listOf(sort), filters = filters
+  )
 
   /**
    * Compatibility constructor for old clients.
    */
   @Deprecated("Please use other constructor setting the assignedToMeOnly.")
-  constructor(user: User, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String? = null, filters: List<String> = listOf()) : this(
+  constructor(user: User, page: Int = 0, size: Int = Int.MAX_VALUE, sort: List<String> = listOf(), filters: List<String> = listOf()) : this(
     user = user, assignedToMeOnly = false, page = page, size = size, sort = sort, filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/sort/Sorter.kt
+++ b/view/view-api/src/main/kotlin/sort/Sorter.kt
@@ -17,7 +17,9 @@ import kotlin.Comparator
  * @return comparator for the sort string.
  */
 internal fun dataComparator(sort: String?): DataEntryComparator? {
-  if (sort.isNullOrBlank()) return null
+  if (sort.isNullOrBlank()) {
+    return null
+  }
   val sortDirection = parse(sort) ?: return null
   val fieldName = if (isDataEntryAttribute(sort.substring(1))) {
     sort.substring(1).substring(DATA_PREFIX.length)
@@ -28,7 +30,6 @@ internal fun dataComparator(sort: String?): DataEntryComparator? {
   return DataEntryComparator(field to sortDirection)
 }
 
-// TODO: why do i need to cast?
 /**
  * Creates a new data entry comparator.
  * @param sort a list of sort strings (like +field or -name)
@@ -44,7 +45,9 @@ fun dataComparator(sort: List<String>): Comparator<DataEntry>? {
  * @return comparator for the sort string.
  */
 internal fun taskComparator(sort: String?): TaskComparator? {
-  if (sort.isNullOrBlank()) return null
+  if (sort.isNullOrBlank()) {
+    return null
+  }
   val sortDirection = parse(sort) ?: return null
   val fieldName = if (isTaskAttribute(sort.substring(1))) {
     sort.substring(1).substring(TASK_PREFIX.length)
@@ -62,7 +65,9 @@ internal fun taskComparator(sort: String?): TaskComparator? {
  * @return comparator for the sort strings.
  */
 fun taskComparator(sort: List<String>): Comparator<Task>? {
-  if (sort.isEmpty()) return null
+  if (sort.isEmpty()) {
+    return null
+  }
   return mapComparator(sort.map { taskComparator(it) })
 }
 
@@ -72,7 +77,9 @@ fun taskComparator(sort: List<String>): Comparator<Task>? {
  * @return comparator for the sort string.
  */
 internal fun taskWithDataEntriesComparator(sort: String?): TasksWithDataEntriesComparator? {
-  if (sort.isNullOrBlank()) return null
+  if (sort.isNullOrBlank()) {
+    return null
+  }
   val sortDirection = parse(sort) ?: return null
   val fieldName = if (isTaskAttribute(sort.substring(1))) {
     sort.substring(1).substring(TASK_PREFIX.length)
@@ -92,7 +99,9 @@ internal fun taskWithDataEntriesComparator(sort: String?): TasksWithDataEntriesC
  * @return comparator for the sort strings.
  */
 fun taskWithDataEntriesComparator(sort: List<String>): Comparator<TaskWithDataEntries>? {
-  if (sort.isEmpty()) return null;
+  if (sort.isEmpty()) {
+    return null
+  };
   return mapComparator(sort.map { taskWithDataEntriesComparator(it) });
 }
 

--- a/view/view-api/src/main/kotlin/sort/Sorter.kt
+++ b/view/view-api/src/main/kotlin/sort/Sorter.kt
@@ -2,19 +2,21 @@ package io.holunda.polyflow.view.sort
 
 import io.holunda.polyflow.view.DataEntry
 import io.holunda.polyflow.view.Task
+import io.holunda.polyflow.view.TaskWithDataEntries
 import io.holunda.polyflow.view.filter.*
 import io.holunda.polyflow.view.filter.isDataEntryAttribute
 import io.holunda.polyflow.view.filter.isTaskAttribute
 import java.lang.reflect.Field
 import java.time.Instant
 import java.util.*
+import kotlin.Comparator
 
 /**
  * Creates a new data entry comparator.
  * @param sort a sort string (like +field or -name)
  * @return comparator for the sort string.
  */
-fun dataComparator(sort: String?): DataEntryComparator? {
+internal fun dataComparator(sort: String?): DataEntryComparator? {
   if (sort.isNullOrBlank()) return null
   val sortDirection = parse(sort) ?: return null
   val fieldName = if (isDataEntryAttribute(sort.substring(1))) {
@@ -26,12 +28,22 @@ fun dataComparator(sort: String?): DataEntryComparator? {
   return DataEntryComparator(field to sortDirection)
 }
 
+// TODO: why do i need to cast?
+/**
+ * Creates a new data entry comparator.
+ * @param sort a list of sort strings (like +field or -name)
+ * @return comparator for the sort strings.
+ */
+fun dataComparator(sort: List<String>): Comparator<DataEntry>? {
+  return mapComparator(sort.map { dataComparator(it) })
+}
+
 /**
  * Creates a new task comparator.
  * @param sort a sort string (like +field or -name)
  * @return comparator for the sort string.
  */
-fun taskComparator(sort: String?): TaskComparator? {
+internal fun taskComparator(sort: String?): TaskComparator? {
   if (sort.isNullOrBlank()) return null
   val sortDirection = parse(sort) ?: return null
   val fieldName = if (isTaskAttribute(sort.substring(1))) {
@@ -45,11 +57,21 @@ fun taskComparator(sort: String?): TaskComparator? {
 }
 
 /**
+ * Creates a new task comparator.
+ * @param sort a list of sort strings (like +field or -name)
+ * @return comparator for the sort strings.
+ */
+fun taskComparator(sort: List<String>): Comparator<Task>? {
+  if (sort.isEmpty()) return null
+  return mapComparator(sort.map { taskComparator(it) })
+}
+
+/**
  * Creates a new task with data entries comparator.
  * @param sort a sort string (like +field or -name)
  * @return comparator for the sort string.
  */
-fun taskWithDataEntriesComparator(sort: String?): TasksWithDataEntriesComparator? {
+internal fun taskWithDataEntriesComparator(sort: String?): TasksWithDataEntriesComparator? {
   if (sort.isNullOrBlank()) return null
   val sortDirection = parse(sort) ?: return null
   val fieldName = if (isTaskAttribute(sort.substring(1))) {
@@ -62,6 +84,20 @@ fun taskWithDataEntriesComparator(sort: String?): TasksWithDataEntriesComparator
   val field = extractField(targetClass = Task::class.java, name = fieldName)
     ?: return null
   return TasksWithDataEntriesComparator(field to sortDirection)
+}
+
+/**
+ * Creates a new task with data entries comparator.
+ * @param sort a list of sort strings (like +field or -name)
+ * @return comparator for the sort strings.
+ */
+fun taskWithDataEntriesComparator(sort: List<String>): Comparator<TaskWithDataEntries>? {
+  if (sort.isEmpty()) return null;
+  return mapComparator(sort.map { taskWithDataEntriesComparator(it) });
+}
+
+private fun <T> mapComparator(sort: List<Comparator<T>?>): Comparator<T>? {
+  return sort.filterNotNull().reduceOrNull { combined, element -> combined.then(element) }
 }
 
 /**

--- a/view/view-api/src/test/kotlin/query/PageableSortableQueryTest.kt
+++ b/view/view-api/src/test/kotlin/query/PageableSortableQueryTest.kt
@@ -13,20 +13,20 @@ import kotlin.reflect.full.declaredMemberProperties
 
 internal class PageableSortableQueryTest {
 
-  private val createTimeAsc = "+createTime"
-  private val nameDesc = "-name"
-  private val badField = "+someTaskField"
-  private val badOrdering = "*createTime"
+  private val createTimeAsc = listOf("+createTime")
+  private val nameDesc = listOf("-name")
+  private val badField = listOf("+someTaskField")
+  private val badOrdering = listOf("*createTime")
   private val user = User(username = "kermit", groups = setOf())
 
   @Test
   fun should_sanitize_task_query() {
     assertThat(AllTasksQuery(sort = createTimeAsc).apply { sanitizeSort(Task::class) }.sort).isEqualTo(createTimeAsc)
-    assertThat(AllTasksQuery(sort = null).apply { sanitizeSort(Task::class) }.sort).isNull()
+    assertThat(AllTasksQuery(sort = listOf()).apply { sanitizeSort(Task::class) }.sort).isNull()
     val badFieldException = assertThrows<IllegalArgumentException> { AllTasksQuery(sort = badField).apply { sanitizeSort(Task::class) } }
     assertThat(badFieldException.message).isEqualTo(
       "Sort parameter must be one of ${Task::class.declaredMemberProperties.joinToString(", ") { it.name }} but it was ${
-        badField.substring(
+        badField[0].substring(
           1
         )
       }."
@@ -39,12 +39,12 @@ internal class PageableSortableQueryTest {
   @Test
   fun should_sanitize_task_with_dataentry_query() {
     assertThat(TasksWithDataEntriesForGroupQuery(user = user, sort = createTimeAsc).apply { sanitizeSort(Task::class) }.sort).isEqualTo(createTimeAsc)
-    assertThat(TasksWithDataEntriesForGroupQuery(user = user, sort = null).apply { sanitizeSort(Task::class) }.sort).isNull()
+    assertThat(TasksWithDataEntriesForGroupQuery(user = user, sort = listOf()).apply { sanitizeSort(Task::class) }.sort).isNull()
     val badFieldException =
       assertThrows<IllegalArgumentException> { TasksWithDataEntriesForGroupQuery(user = user, sort = badField).apply { sanitizeSort(Task::class) } }
     assertThat(badFieldException.message).isEqualTo(
       "Sort parameter must be one of ${Task::class.declaredMemberProperties.joinToString(", ") { it.name }} but it was ${
-        badField.substring(
+        badField[0].substring(
           1
         )
       }."
@@ -58,11 +58,11 @@ internal class PageableSortableQueryTest {
   @Test
   fun should_sanitize_dataentry_query() {
     assertThat(DataEntriesQuery(sort = nameDesc).apply { sanitizeSort(DataEntry::class) }.sort).isEqualTo(nameDesc)
-    assertThat(DataEntriesQuery(sort = null).apply { sanitizeSort(DataEntry::class) }.sort).isNull()
+    assertThat(DataEntriesQuery(sort = listOf()).apply { sanitizeSort(DataEntry::class) }.sort).isNull()
     val badFieldException = assertThrows<IllegalArgumentException> { DataEntriesQuery(sort = badField).apply { sanitizeSort(DataEntry::class) } }
     assertThat(badFieldException.message).isEqualTo(
       "Sort parameter must be one of ${DataEntry::class.declaredMemberProperties.joinToString(", ") { it.name }} but it was ${
-        badField.substring(
+        badField[0].substring(
           1
         )
       }."

--- a/view/view-api/src/test/kotlin/query/PageableSortableQueryTest.kt
+++ b/view/view-api/src/test/kotlin/query/PageableSortableQueryTest.kt
@@ -22,7 +22,7 @@ internal class PageableSortableQueryTest {
   @Test
   fun should_sanitize_task_query() {
     assertThat(AllTasksQuery(sort = createTimeAsc).apply { sanitizeSort(Task::class) }.sort).isEqualTo(createTimeAsc)
-    assertThat(AllTasksQuery(sort = listOf()).apply { sanitizeSort(Task::class) }.sort).isNull()
+    assertThat(AllTasksQuery(sort = listOf()).apply { sanitizeSort(Task::class) }.sort).isEmpty()
     val badFieldException = assertThrows<IllegalArgumentException> { AllTasksQuery(sort = badField).apply { sanitizeSort(Task::class) } }
     assertThat(badFieldException.message).isEqualTo(
       "Sort parameter must be one of ${Task::class.declaredMemberProperties.joinToString(", ") { it.name }} but it was ${
@@ -39,7 +39,7 @@ internal class PageableSortableQueryTest {
   @Test
   fun should_sanitize_task_with_dataentry_query() {
     assertThat(TasksWithDataEntriesForGroupQuery(user = user, sort = createTimeAsc).apply { sanitizeSort(Task::class) }.sort).isEqualTo(createTimeAsc)
-    assertThat(TasksWithDataEntriesForGroupQuery(user = user, sort = listOf()).apply { sanitizeSort(Task::class) }.sort).isNull()
+    assertThat(TasksWithDataEntriesForGroupQuery(user = user, sort = listOf()).apply { sanitizeSort(Task::class) }.sort).isEmpty()
     val badFieldException =
       assertThrows<IllegalArgumentException> { TasksWithDataEntriesForGroupQuery(user = user, sort = badField).apply { sanitizeSort(Task::class) } }
     assertThat(badFieldException.message).isEqualTo(
@@ -58,7 +58,7 @@ internal class PageableSortableQueryTest {
   @Test
   fun should_sanitize_dataentry_query() {
     assertThat(DataEntriesQuery(sort = nameDesc).apply { sanitizeSort(DataEntry::class) }.sort).isEqualTo(nameDesc)
-    assertThat(DataEntriesQuery(sort = listOf()).apply { sanitizeSort(DataEntry::class) }.sort).isNull()
+    assertThat(DataEntriesQuery(sort = listOf()).apply { sanitizeSort(DataEntry::class) }.sort).isEmpty()
     val badFieldException = assertThrows<IllegalArgumentException> { DataEntriesQuery(sort = badField).apply { sanitizeSort(DataEntry::class) } }
     assertThat(badFieldException.message).isEqualTo(
       "Sort parameter must be one of ${DataEntry::class.declaredMemberProperties.joinToString(", ") { it.name }} but it was ${


### PR DESCRIPTION
Sort parameter now accepts a list of String instead. Old api (single string) is kept and marked as deprecated. 
Fixes #847 