### PR TITLE
fix(#883): use empty list instead of list with empty string

### DIFF
--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceDataEntryITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceDataEntryITest.kt
@@ -313,6 +313,7 @@ internal class JpaPolyflowViewServiceDataEntryITest {
     assertThat(result.payload.elements.map { it.entryId }).containsExactly(id2, id, id4)
   }
 
+  @Suppress("DEPRECATION")
   @Test
   fun `sort should be backwards compatible`() {
 

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceTaskITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceTaskITest.kt
@@ -285,6 +285,28 @@ internal class JpaPolyflowViewServiceTaskITest {
   }
 
   @Test
+  fun `should sort with empty string, null or empty list correctly`() {
+    val sortWithNullQuery = jpaPolyflowViewService.query(AllTasksWithDataEntriesQuery(
+      sort = null
+    ))
+
+    val sortWithEmptyStringQuery =jpaPolyflowViewService.query(AllTasksWithDataEntriesQuery(
+      sort = ""
+    ))
+
+    val sortWithEmptyListQuery =jpaPolyflowViewService.query(AllTasksWithDataEntriesQuery(
+      sort = listOf()
+    ))
+
+    val sortWithSortNutSuppliedQuery = jpaPolyflowViewService.query(AllTasksWithDataEntriesQuery())
+
+    assertThat(sortWithEmptyStringQuery.elements).isEqualTo(sortWithSortNutSuppliedQuery.elements)
+    assertThat(sortWithSortNutSuppliedQuery.elements).isEqualTo(sortWithEmptyListQuery.elements)
+    assertThat(sortWithEmptyListQuery.elements).isEqualTo(sortWithEmptyStringQuery.elements)
+    assertThat(sortWithSortNutSuppliedQuery.elements).isEqualTo(sortWithEmptyStringQuery.elements)
+  }
+
+  @Test
   fun `should find the task with data entries and sort by multiple correctly`() {
     val query = jpaPolyflowViewService.query(AllTasksWithDataEntriesQuery(
       sort = listOf("+priority", "-name")
@@ -323,6 +345,12 @@ internal class JpaPolyflowViewServiceTaskITest {
         assignedToMeOnly = false
       ))
     }.message).isEqualTo("Sort must start either with '+' or '-' but it was starting with '*'")
+
+    assertThat(assertThrows<IllegalArgumentException> {
+      jpaPolyflowViewService.query(AllTasksWithDataEntriesQuery(
+        sort = listOf("")
+      ))
+    }.message).isEqualTo("Sort parameter can not be blank")
 
   }
 

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceTaskITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceTaskITest.kt
@@ -284,6 +284,7 @@ internal class JpaPolyflowViewServiceTaskITest {
     assertThat(strawhatsInverse.elements.map { it.task.id }).containsExactly(id4, id3)
   }
 
+  @Suppress("DEPRECATION")
   @Test
   fun `should sort with empty string, null or empty list correctly`() {
     val sortWithNullQuery = jpaPolyflowViewService.query(AllTasksWithDataEntriesQuery(
@@ -350,7 +351,7 @@ internal class JpaPolyflowViewServiceTaskITest {
       jpaPolyflowViewService.query(AllTasksWithDataEntriesQuery(
         sort = listOf("")
       ))
-    }.message).isEqualTo("Sort parameter can not be blank")
+    }.message).isEqualTo("Sort parameter must not be blank")
 
   }
 

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceTaskITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceTaskITest.kt
@@ -299,12 +299,13 @@ internal class JpaPolyflowViewServiceTaskITest {
       sort = listOf()
     ))
 
-    val sortWithSortNutSuppliedQuery = jpaPolyflowViewService.query(AllTasksWithDataEntriesQuery())
+    val sortWithSortNotSuppliedQuery = jpaPolyflowViewService.query(AllTasksWithDataEntriesQuery())
 
-    assertThat(sortWithEmptyStringQuery.elements).isEqualTo(sortWithSortNutSuppliedQuery.elements)
-    assertThat(sortWithSortNutSuppliedQuery.elements).isEqualTo(sortWithEmptyListQuery.elements)
-    assertThat(sortWithEmptyListQuery.elements).isEqualTo(sortWithEmptyStringQuery.elements)
-    assertThat(sortWithSortNutSuppliedQuery.elements).isEqualTo(sortWithEmptyStringQuery.elements)
+
+    assertThat(sortWithNullQuery.elements).isEqualTo(sortWithEmptyStringQuery.elements)
+    assertThat(sortWithEmptyStringQuery.elements).isEqualTo(sortWithEmptyListQuery.elements)
+    assertThat(sortWithEmptyListQuery.elements).isEqualTo(sortWithSortNotSuppliedQuery.elements)
+    assertThat(sortWithSortNotSuppliedQuery.elements).isEqualTo(sortWithNullQuery.elements)
   }
 
   @Test

--- a/view/view-api/src/main/kotlin/query/PageableSortableQuery.kt
+++ b/view/view-api/src/main/kotlin/query/PageableSortableQuery.kt
@@ -28,8 +28,9 @@ interface PageableSortableQuery {
     if (sort.isEmpty()) {
       return
     }
-    sort.forEach {
 
+    sort.forEach {
+      require(it.isNotBlank()) { "Sort parameter can not be blank" }
       val direction = it.substring(0, 1)
       require(
         direction == ASCENDING.sign
@@ -43,5 +44,6 @@ interface PageableSortableQuery {
       }
     }
   }
+
 
 }

--- a/view/view-api/src/main/kotlin/query/PageableSortableQuery.kt
+++ b/view/view-api/src/main/kotlin/query/PageableSortableQuery.kt
@@ -30,7 +30,7 @@ interface PageableSortableQuery {
     }
 
     sort.forEach {
-      require(it.isNotBlank()) { "Sort parameter can not be blank" }
+      require(it.isNotBlank() && it.isNotEmpty()) { "Sort parameter must not be blank" }
       val direction = it.substring(0, 1)
       require(
         direction == ASCENDING.sign

--- a/view/view-api/src/main/kotlin/query/data/DataEntriesForDataEntryTypeQuery.kt
+++ b/view/view-api/src/main/kotlin/query/data/DataEntriesForDataEntryTypeQuery.kt
@@ -19,11 +19,11 @@ data class DataEntriesForDataEntryTypeQuery(
 ) : FilterQuery<DataEntry>, PageableSortableQuery {
 
   @Deprecated("Please use other constructor setting sort as List<String>")
-  constructor(entryType: EntryType, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String): this(
+  constructor(entryType: EntryType, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String) : this(
     entryType = entryType,
     page = page,
     size = size,
-    sort = listOf(sort),
+    sort = if (sort.isBlank()) listOf() else listOf(sort),
   )
 
   override fun applyFilter(element: DataEntry) = element.entryType == this.entryType

--- a/view/view-api/src/main/kotlin/query/data/DataEntriesForDataEntryTypeQuery.kt
+++ b/view/view-api/src/main/kotlin/query/data/DataEntriesForDataEntryTypeQuery.kt
@@ -19,11 +19,15 @@ data class DataEntriesForDataEntryTypeQuery(
 ) : FilterQuery<DataEntry>, PageableSortableQuery {
 
   @Deprecated("Please use other constructor setting sort as List<String>")
-  constructor(entryType: EntryType, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String) : this(
+  constructor(entryType: EntryType, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String?) : this(
     entryType = entryType,
     page = page,
     size = size,
-    sort = if (sort.isBlank()) listOf() else listOf(sort),
+    sort = if (sort.isNullOrBlank()) {
+      listOf()
+    } else {
+      listOf(sort)
+    },
   )
 
   override fun applyFilter(element: DataEntry) = element.entryType == this.entryType

--- a/view/view-api/src/main/kotlin/query/data/DataEntriesForUserQuery.kt
+++ b/view/view-api/src/main/kotlin/query/data/DataEntriesForUserQuery.kt
@@ -30,7 +30,7 @@ data class DataEntriesForUserQuery(
     user = user,
     page = page,
     size = size,
-    sort = listOf(sort),
+    sort = if (sort.isBlank()) listOf() else listOf(sort),
     filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/query/data/DataEntriesForUserQuery.kt
+++ b/view/view-api/src/main/kotlin/query/data/DataEntriesForUserQuery.kt
@@ -26,11 +26,15 @@ data class DataEntriesForUserQuery(
 ) : FilterQuery<DataEntry>, PageableSortableQuery {
 
   @Deprecated("Please use other constructor setting sort as List<String>")
-  constructor(user: User, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
+  constructor(user: User, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String?, filters: List<String> = listOf()): this(
     user = user,
     page = page,
     size = size,
-    sort = if (sort.isBlank()) listOf() else listOf(sort),
+    sort = if (sort.isNullOrBlank()) {
+      listOf()
+    } else {
+      listOf(sort)
+    },
     filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/query/data/DataEntriesQuery.kt
+++ b/view/view-api/src/main/kotlin/query/data/DataEntriesQuery.kt
@@ -26,7 +26,7 @@ data class DataEntriesQuery(
   constructor(page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
     page = page,
     size = size,
-    sort = listOf(sort),
+    sort = if (sort.isBlank()) listOf() else listOf(sort),
     filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/query/data/DataEntriesQuery.kt
+++ b/view/view-api/src/main/kotlin/query/data/DataEntriesQuery.kt
@@ -23,10 +23,14 @@ data class DataEntriesQuery(
 ) : FilterQuery<DataEntry>, PageableSortableQuery {
 
   @Deprecated("Please use other constructor setting sort as List<String>")
-  constructor(page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
+  constructor(page: Int = 0, size: Int = Int.MAX_VALUE, sort: String?, filters: List<String> = listOf()): this(
     page = page,
     size = size,
-    sort = if (sort.isBlank()) listOf() else listOf(sort),
+    sort = if (sort.isNullOrBlank()) {
+      listOf()
+    } else {
+      listOf(sort)
+    },
     filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/query/task/AllTasksQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/AllTasksQuery.kt
@@ -22,7 +22,7 @@ data class AllTasksQuery(
   constructor(page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
     page = page,
     size = size,
-    sort = listOf(sort),
+    sort = if (sort.isBlank()) listOf() else listOf(sort),
     filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/query/task/AllTasksQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/AllTasksQuery.kt
@@ -19,10 +19,14 @@ data class AllTasksQuery(
 ) : PageableSortableFilteredTaskQuery {
 
   @Deprecated("Please use other constructor setting sort as List<String>")
-  constructor(page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
+  constructor(page: Int = 0, size: Int = Int.MAX_VALUE, sort: String?, filters: List<String> = listOf()): this(
     page = page,
     size = size,
-    sort = if (sort.isBlank()) listOf() else listOf(sort),
+    sort = if (sort.isNullOrBlank()) {
+      listOf()
+    } else {
+      listOf(sort)
+    },
     filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/query/task/AllTasksWithDataEntriesQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/AllTasksWithDataEntriesQuery.kt
@@ -20,10 +20,14 @@ data class AllTasksWithDataEntriesQuery(
 ) : FilterQuery<TaskWithDataEntries>, PageableSortableQuery {
 
   @Deprecated("Please use other constructor setting sort as List<String>")
-  constructor(page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
+  constructor(page: Int = 0, size: Int = Int.MAX_VALUE, sort: String? , filters: List<String> = listOf()) : this(
     page = page,
     size = size,
-    sort = if (sort.isBlank()) listOf() else listOf(sort),
+    sort = if (sort.isNullOrBlank()) {
+      listOf()
+    } else {
+      listOf(sort)
+    },
     filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/query/task/AllTasksWithDataEntriesQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/AllTasksWithDataEntriesQuery.kt
@@ -23,7 +23,7 @@ data class AllTasksWithDataEntriesQuery(
   constructor(page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
     page = page,
     size = size,
-    sort = listOf(sort),
+    sort = if (sort.isBlank()) listOf() else listOf(sort),
     filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/query/task/TasksForCandidateUserAndGroupQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksForCandidateUserAndGroupQuery.kt
@@ -22,12 +22,16 @@ data class TasksForCandidateUserAndGroupQuery(
 ) : PageableSortableFilteredTaskQuery {
 
   @Deprecated("Please use other constructor setting sort as List<String>")
-  constructor(user: User, includeAssigned: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
+  constructor(user: User, includeAssigned: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String?, filters: List<String> = listOf()): this(
     user = user,
     includeAssigned = includeAssigned,
     page = page,
     size = size,
-    sort = if (sort.isBlank()) listOf() else listOf(sort),
+    sort = if (sort.isNullOrBlank()) {
+      listOf()
+    } else {
+      listOf(sort)
+    },
     filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/query/task/TasksForCandidateUserAndGroupQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksForCandidateUserAndGroupQuery.kt
@@ -27,7 +27,7 @@ data class TasksForCandidateUserAndGroupQuery(
     includeAssigned = includeAssigned,
     page = page,
     size = size,
-    sort = listOf(sort),
+    sort = if (sort.isBlank()) listOf() else listOf(sort),
     filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/query/task/TasksForGroupQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksForGroupQuery.kt
@@ -29,7 +29,7 @@ data class TasksForGroupQuery(
     includeAssigned = includeAssigned,
     page = page,
     size = size,
-    sort = listOf(sort),
+    sort = if (sort.isBlank()) listOf() else listOf(sort),
     filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/query/task/TasksForGroupQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksForGroupQuery.kt
@@ -24,12 +24,16 @@ data class TasksForGroupQuery(
 ) : PageableSortableFilteredTaskQuery {
 
   @Deprecated("Please use other constructor setting sort as List<String>")
-  constructor(user: User, includeAssigned: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
+  constructor(user: User, includeAssigned: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String?, filters: List<String> = listOf()): this(
     user = user,
     includeAssigned = includeAssigned,
     page = page,
     size = size,
-    sort = if (sort.isBlank()) listOf() else listOf(sort),
+    sort = if (sort.isNullOrBlank()) {
+      listOf()
+    } else {
+      listOf(sort)
+    },
     filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/query/task/TasksForUserQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksForUserQuery.kt
@@ -27,7 +27,7 @@ data class TasksForUserQuery(
     assignedToMeOnly = assignedToMeOnly,
     page = page,
     size = size,
-    sort = listOf(sort),
+    sort = if (sort.isBlank()) listOf() else listOf(sort),
     filters = filters
   )
 
@@ -35,12 +35,12 @@ data class TasksForUserQuery(
    * Compatibility constructor for old clients.
    */
   @Deprecated(message = "Please use other constructor setting the assignedToMeOnly.")
-  constructor(user: User, page: Int = 0, size: Int = Int.MAX_VALUE, sort: List<String> = listOf(), filters: List<String> = listOf()): this(
+  constructor(user: User, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String? = null, filters: List<String> = listOf()): this(
     user = user,
     assignedToMeOnly = false,
     page = page,
     size = size,
-    sort = sort,
+    sort = if (sort.isNullOrBlank()) listOf() else listOf(sort),
     filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/query/task/TasksForUserQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksForUserQuery.kt
@@ -22,12 +22,16 @@ data class TasksForUserQuery(
 ) : PageableSortableFilteredTaskQuery {
 
   @Deprecated("Please use other constructor setting sort as List<String>")
-  constructor(user: User, assignedToMeOnly: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()): this(
+  constructor(user: User, assignedToMeOnly: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String?, filters: List<String> = listOf()): this(
     user = user,
     assignedToMeOnly = assignedToMeOnly,
     page = page,
     size = size,
-    sort = if (sort.isBlank()) listOf() else listOf(sort),
+    sort = if (sort.isNullOrBlank()) {
+      listOf()
+    } else {
+      listOf(sort)
+    },
     filters = filters
   )
 
@@ -40,7 +44,11 @@ data class TasksForUserQuery(
     assignedToMeOnly = false,
     page = page,
     size = size,
-    sort = if (sort.isNullOrBlank()) listOf() else listOf(sort),
+    sort = if (sort.isNullOrBlank()) {
+      listOf()
+    } else {
+      listOf(sort)
+    },
     filters = filters
   )
 

--- a/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForGroupQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForGroupQuery.kt
@@ -25,11 +25,16 @@ data class TasksWithDataEntriesForGroupQuery(
 
   @Deprecated("Please use other constructor setting sort as List<String>")
   constructor(user: User, includeAssigned: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String?, filters: List<String> = listOf()) : this(
-    user = user, includeAssigned = includeAssigned, page = page, size = size, sort = if (sort.isNullOrBlank()) {
-    listOf()
-  } else {
-    listOf(sort)
-  }, filters = filters
+    user = user,
+    includeAssigned = includeAssigned,
+    page = page,
+    size = size,
+    sort = if (sort.isNullOrBlank()) {
+      listOf()
+    } else {
+      listOf(sort)
+    },
+    filters = filters
   )
 
   override fun applyFilter(element: TaskWithDataEntries): Boolean =

--- a/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForGroupQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForGroupQuery.kt
@@ -24,8 +24,12 @@ data class TasksWithDataEntriesForGroupQuery(
 ) : FilterQuery<TaskWithDataEntries>, PageableSortableQuery {
 
   @Deprecated("Please use other constructor setting sort as List<String>")
-  constructor(user: User, includeAssigned: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()) : this(
-    user = user, includeAssigned = includeAssigned, page = page, size = size, if (sort.isBlank()) listOf() else listOf(sort), filters = filters
+  constructor(user: User, includeAssigned: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String?, filters: List<String> = listOf()) : this(
+    user = user, includeAssigned = includeAssigned, page = page, size = size, sort = if (sort.isNullOrBlank()) {
+    listOf()
+  } else {
+    listOf(sort)
+  }, filters = filters
   )
 
   override fun applyFilter(element: TaskWithDataEntries): Boolean =

--- a/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForGroupQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForGroupQuery.kt
@@ -25,7 +25,7 @@ data class TasksWithDataEntriesForGroupQuery(
 
   @Deprecated("Please use other constructor setting sort as List<String>")
   constructor(user: User, includeAssigned: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()) : this(
-    user = user, includeAssigned = includeAssigned, page = page, size = size, sort = listOf(sort), filters = filters
+    user = user, includeAssigned = includeAssigned, page = page, size = size, if (sort.isBlank()) listOf() else listOf(sort), filters = filters
   )
 
   override fun applyFilter(element: TaskWithDataEntries): Boolean =

--- a/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForUserQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForUserQuery.kt
@@ -25,15 +25,15 @@ data class TasksWithDataEntriesForUserQuery(
 
   @Deprecated("Please use other constructor setting sort as List<String>")
   constructor(user: User, assignedToMeOnly: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()) : this(
-    user = user, assignedToMeOnly = assignedToMeOnly, page = page, size = size, sort = listOf(sort), filters = filters
+    user = user, assignedToMeOnly = assignedToMeOnly, page = page, size = size, sort = if (sort.isBlank()) listOf() else listOf(sort), filters = filters
   )
 
   /**
    * Compatibility constructor for old clients.
    */
   @Deprecated("Please use other constructor setting the assignedToMeOnly.")
-  constructor(user: User, page: Int = 0, size: Int = Int.MAX_VALUE, sort: List<String> = listOf(), filters: List<String> = listOf()) : this(
-    user = user, assignedToMeOnly = false, page = page, size = size, sort = sort, filters = filters
+  constructor(user: User, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String? = null, filters: List<String> = listOf()) : this(
+    user = user, assignedToMeOnly = false, page = page, size = size, sort = if (sort.isNullOrBlank()) listOf() else listOf(sort), filters = filters
   )
 
   override fun applyFilter(element: TaskWithDataEntries): Boolean =

--- a/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForUserQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForUserQuery.kt
@@ -24,8 +24,12 @@ data class TasksWithDataEntriesForUserQuery(
 ) : FilterQuery<TaskWithDataEntries>, PageableSortableQuery {
 
   @Deprecated("Please use other constructor setting sort as List<String>")
-  constructor(user: User, assignedToMeOnly: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String, filters: List<String> = listOf()) : this(
-    user = user, assignedToMeOnly = assignedToMeOnly, page = page, size = size, sort = if (sort.isBlank()) listOf() else listOf(sort), filters = filters
+  constructor(user: User, assignedToMeOnly: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String?, filters: List<String> = listOf()) : this(
+    user = user, assignedToMeOnly = assignedToMeOnly, page = page, size = size, sort = if (sort.isNullOrBlank()) {
+    listOf()
+  } else {
+    listOf(sort)
+  }, filters = filters
   )
 
   /**
@@ -33,7 +37,11 @@ data class TasksWithDataEntriesForUserQuery(
    */
   @Deprecated("Please use other constructor setting the assignedToMeOnly.")
   constructor(user: User, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String? = null, filters: List<String> = listOf()) : this(
-    user = user, assignedToMeOnly = false, page = page, size = size, sort = if (sort.isNullOrBlank()) listOf() else listOf(sort), filters = filters
+    user = user, assignedToMeOnly = false, page = page, size = size, sort = if (sort.isNullOrBlank()) {
+    listOf()
+  } else {
+    listOf(sort)
+  }, filters = filters
   )
 
   override fun applyFilter(element: TaskWithDataEntries): Boolean =

--- a/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForUserQuery.kt
+++ b/view/view-api/src/main/kotlin/query/task/TasksWithDataEntriesForUserQuery.kt
@@ -25,11 +25,16 @@ data class TasksWithDataEntriesForUserQuery(
 
   @Deprecated("Please use other constructor setting sort as List<String>")
   constructor(user: User, assignedToMeOnly: Boolean = false, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String?, filters: List<String> = listOf()) : this(
-    user = user, assignedToMeOnly = assignedToMeOnly, page = page, size = size, sort = if (sort.isNullOrBlank()) {
-    listOf()
-  } else {
-    listOf(sort)
-  }, filters = filters
+    user = user,
+    assignedToMeOnly = assignedToMeOnly,
+    page = page,
+    size = size,
+    sort = if (sort.isNullOrBlank()) {
+      listOf()
+    } else {
+      listOf(sort)
+    },
+    filters = filters
   )
 
   /**
@@ -37,11 +42,16 @@ data class TasksWithDataEntriesForUserQuery(
    */
   @Deprecated("Please use other constructor setting the assignedToMeOnly.")
   constructor(user: User, page: Int = 0, size: Int = Int.MAX_VALUE, sort: String? = null, filters: List<String> = listOf()) : this(
-    user = user, assignedToMeOnly = false, page = page, size = size, sort = if (sort.isNullOrBlank()) {
-    listOf()
-  } else {
-    listOf(sort)
-  }, filters = filters
+    user = user,
+    assignedToMeOnly = false,
+    page = page,
+    size = size,
+    sort = if (sort.isNullOrBlank()) {
+      listOf()
+    } else {
+      listOf(sort)
+    },
+    filters = filters
   )
 
   override fun applyFilter(element: TaskWithDataEntries): Boolean =

--- a/view/view-api/src/test/kotlin/query/PageableSortableQueryTest.kt
+++ b/view/view-api/src/test/kotlin/query/PageableSortableQueryTest.kt
@@ -19,6 +19,24 @@ internal class PageableSortableQueryTest {
   private val badOrdering = listOf("*createTime")
   private val user = User(username = "kermit", groups = setOf())
 
+
+  @Test
+  fun should_sanitize_blank_sort() {
+
+    class TestQuery(
+      override val page: Int,
+      override val size: Int,
+      override val sort: List<String>,
+    ) : PageableSortableQuery
+
+    assertThat(assertThrows<IllegalArgumentException> { TestQuery(1, 1, listOf("")).sanitizeSort(Task::class) }.message).isEqualTo("Sort parameter must not be blank")
+    assertThat(assertThrows<IllegalArgumentException> { TestQuery(1, 1, listOf("\t")).sanitizeSort(Task::class) }.message).isEqualTo("Sort parameter must not be blank")
+    assertThat(assertThrows<IllegalArgumentException> { TestQuery(1, 1, listOf("\t\r\n")).sanitizeSort(Task::class) }.message).isEqualTo("Sort parameter must not be blank")
+    assertThat(assertThrows<IllegalArgumentException> { TestQuery(1, 1, listOf("  \t")).sanitizeSort(Task::class) }.message).isEqualTo("Sort parameter must not be blank")
+    assertThat(assertThrows<IllegalArgumentException> { TestQuery(1, 1, listOf("  \n")).sanitizeSort(Task::class) }.message).isEqualTo("Sort parameter must not be blank")
+  }
+
+
   @Test
   fun should_sanitize_task_query() {
     assertThat(AllTasksQuery(sort = createTimeAsc).apply { sanitizeSort(Task::class) }.sort).isEqualTo(createTimeAsc)


### PR DESCRIPTION
Fixed an error from #875 where a List with an empty sort string would produce a StringIndexOutOfBoundsException. 
Fixes #883 