### PR TITLE
Find DataEntries by user involvement

### DIFF
--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewDataEntryService.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewDataEntryService.kt
@@ -16,6 +16,7 @@ import io.holunda.polyflow.view.jpa.auth.AuthorizationPrincipal.Companion.user
 import io.holunda.polyflow.view.jpa.data.*
 import io.holunda.polyflow.view.jpa.data.DataEntryRepository.Companion.hasEntryId
 import io.holunda.polyflow.view.jpa.data.DataEntryRepository.Companion.hasEntryType
+import io.holunda.polyflow.view.jpa.data.DataEntryRepository.Companion.hasUserInvolvement
 import io.holunda.polyflow.view.jpa.data.DataEntryRepository.Companion.isAuthorizedFor
 import io.holunda.polyflow.view.jpa.update.updateDataEntryQuery
 import io.holunda.polyflow.view.query.PageableSortableQuery
@@ -78,8 +79,10 @@ class JpaPolyflowViewDataEntryService(
     val criteria: List<Criterion> = toCriteria(query.filters)
     val specification = criteria.toDataEntrySpecification(polyflowJpaViewProperties.includeCorrelatedDataEntriesInDataEntryQueries)
     val pageRequest = pageRequest(query.page, query.size, query.sort)
-
-    val page = dataEntryRepository.findAll(specification.and(isAuthorizedFor(authorizedPrincipals)), pageRequest)
+    val userQuery = if (query.involvementsOnly) {
+      isAuthorizedFor(authorizedPrincipals).and(hasUserInvolvement(query.user.username))
+    } else { isAuthorizedFor(authorizedPrincipals)   }
+    val page = dataEntryRepository.findAll(specification.and(userQuery), pageRequest)
     return constructDataEntryResponse(page)
   }
 

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/data/DataEntryRepository.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/data/DataEntryRepository.kt
@@ -57,6 +57,15 @@ interface DataEntryRepository : CrudRepository<DataEntryEntity, DataEntryId>, Jp
         )
       }
 
+    fun hasUserInvolvement(userName: String): Specification<DataEntryEntity> =
+      Specification {dataEntry, _, builder ->
+        builder.equal(
+          dataEntry.join<DataEntryEntity, Set<ProtocolElement>>(DataEntryEntity::protocol.name)
+            .get<String>(ProtocolElement::username.name),
+          userName
+        )
+      }
+
     /**
      * Specification for the user-defined state.
      */

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/data/DataEntryRepository.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/data/DataEntryRepository.kt
@@ -57,6 +57,9 @@ interface DataEntryRepository : CrudRepository<DataEntryEntity, DataEntryId>, Jp
         )
       }
 
+    /**
+     * Specification for data entries to check if a user appears in any ProtocolElement
+     */
     fun hasUserInvolvement(userName: String): Specification<DataEntryEntity> =
       Specification {dataEntry, _, builder ->
         builder.equal(

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceDataEntryITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceDataEntryITest.kt
@@ -333,6 +333,14 @@ internal class JpaPolyflowViewServiceDataEntryITest {
     assertThat(result.payload.elements.map { it.entryId }).containsExactly(id2) // id4 is not found by correlation to id2, due to property
   }
 
+  @Test
+  fun `should find data entry by involvements`() {
+    val result = jpaPolyflowViewService.query(
+      DataEntriesForUserQuery(user = User("kermit", mutableSetOf("muppets")), involvementsOnly = true)
+    )
+
+    assertThat(result.payload.elements.map { it.entryId }).containsExactly(id); // user is allowed to see two dataEntries but has only one involvement
+  }
 
   private fun <T : Any> query_updates_have_been_emitted(query: T, id: String, revision: Long) {
     captureEmittedQueryUpdates()

--- a/view/mongo/src/main/kotlin/io/holunda/polyflow/view/mongo/MongoViewService.kt
+++ b/view/mongo/src/main/kotlin/io/holunda/polyflow/view/mongo/MongoViewService.kt
@@ -141,11 +141,13 @@ class MongoViewService(
    */
   @QueryHandler
   override fun query(query: DataEntriesForUserQuery, metaData: MetaData): CompletableFuture<DataEntriesQueryResult> =
-    dataEntryRepository
-      .findAllForUser(
-        username = query.user.username,
-        groupNames = query.user.groups
-      )
+    (if (query.involvementsOnly)
+      dataEntryRepository
+        .findAllForUserWithInvolvement(
+          username = query.user.username,
+          groupNames = query.user.groups
+        )
+    else dataEntryRepository.findAllForUser(username = query.user.username, groupNames = query.user.groups))
       .map { it.dataEntry() }
       .collectList()
       .map { DataEntriesQueryResult(elements = it).slice(query) }

--- a/view/mongo/src/main/kotlin/io/holunda/polyflow/view/mongo/data/DataEntryRepository.kt
+++ b/view/mongo/src/main/kotlin/io/holunda/polyflow/view/mongo/data/DataEntryRepository.kt
@@ -1,8 +1,6 @@
 package io.holunda.polyflow.view.mongo.data
 
-import io.holunda.camunda.taskpool.api.business.DataIdentity
 import io.holunda.camunda.taskpool.api.business.EntryType
-import io.holunda.camunda.taskpool.api.business.dataIdentityString
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.mongodb.repository.Query
@@ -49,6 +47,12 @@ interface DataEntryRepository :
    */
   @Query("{ \$or: [ { 'authorizedUsers' : ?0 }, { 'authorizedGroups' : { \$in: ?1 } } ], 'deleted': { \$ne: true } }")
   fun findAllForUser(@Param("username") username: String, @Param("groupNames") groupNames: Set<String>): Flux<DataEntryDocument>
+
+  /**
+   * Finder for user.
+   */
+  @Query("{ \$or: [ { 'authorizedUsers' : ?0 }, { 'authorizedGroups' : { \$in: ?1 } } ], 'deleted': { \$ne: true }, 'protocol.username': ?0 }")
+  fun findAllForUserWithInvolvement(@Param("username") username: String, @Param("groupNames") groupNames: Set<String>): Flux<DataEntryDocument>
 
   /**
    * Retrieves all data entries for user.

--- a/view/simple/src/test/kotlin/io/holunda/polyflow/view/simple/service/SimpleDataEntryServiceTest.kt
+++ b/view/simple/src/test/kotlin/io/holunda/polyflow/view/simple/service/SimpleDataEntryServiceTest.kt
@@ -67,6 +67,29 @@ class SimpleDataEntryServiceTest {
         type = "Test",
         applicationName = "test-application",
         name = "Test Entry 1",
+        state = ProcessingType.IN_PROGRESS.of("Internal check"),
+        payload = payload,
+        authorizations = listOf(
+          addUser("kermit"),
+          addGroup("muppets")
+        ),
+        updateModification = Modification(
+          time = OffsetDateTime.ofInstant(now, ZoneOffset.UTC).plus(5, ChronoUnit.SECONDS),
+          username = null,
+          log = "Updated",
+          logNotes = "Updates the entry"
+        )
+      ),
+      metaData = RevisionValue(revision = 2).toMetaData()
+    )
+
+    service.on(
+      event = DataEntryUpdatedEvent(
+        entryType = "io.polyflow.test",
+        entryId = id,
+        type = "Test",
+        applicationName = "test-application",
+        name = "Test Entry 1",
         state = ProcessingType.IN_PROGRESS.of("In review"),
         payload = payload,
         authorizations = listOf(
@@ -79,7 +102,7 @@ class SimpleDataEntryServiceTest {
           logNotes = "Updated the entry"
         )
       ),
-      metaData = RevisionValue(revision = 2).toMetaData()
+      metaData = RevisionValue(revision = 3).toMetaData()
     )
 
     service.on(
@@ -306,11 +329,13 @@ class SimpleDataEntryServiceTest {
     assertThat(dataEntry.entryType).isEqualTo("io.polyflow.test")
     assertThat(dataEntry.name).isEqualTo("Test Entry 1")
     assertThat(dataEntry.payload).containsKeys("key", "key-int", "complex")
-    assertThat(dataEntry.protocol.size).isEqualTo(2)
+    assertThat(dataEntry.protocol.size).isEqualTo(3)
     assertThat(dataEntry.protocol[0].time).isEqualTo(now)
     assertThat(dataEntry.protocol[0].username).isEqualTo("kermit")
-    assertThat(dataEntry.protocol[1].time).isEqualTo(now.plus(10, ChronoUnit.SECONDS))
-    assertThat(dataEntry.protocol[1].username).isEqualTo("ironman")
+    assertThat(dataEntry.protocol[1].time).isEqualTo(now.plus(5, ChronoUnit.SECONDS))
+    assertThat(dataEntry.protocol[1].username).isNull()
+    assertThat(dataEntry.protocol[2].time).isEqualTo(now.plus(10, ChronoUnit.SECONDS))
+    assertThat(dataEntry.protocol[2].username).isEqualTo("ironman")
   }
 
   private fun assertTestDataEntry2(dataEntry: DataEntry) {

--- a/view/simple/src/test/kotlin/io/holunda/polyflow/view/simple/service/SimpleDataEntryServiceTest.kt
+++ b/view/simple/src/test/kotlin/io/holunda/polyflow/view/simple/service/SimpleDataEntryServiceTest.kt
@@ -1,0 +1,327 @@
+package io.holunda.polyflow.view.simple.service
+
+import io.holixon.axon.gateway.query.RevisionValue
+import io.holunda.camunda.taskpool.api.business.*
+import io.holunda.camunda.taskpool.api.business.AuthorizationChange.Companion.addGroup
+import io.holunda.camunda.taskpool.api.business.AuthorizationChange.Companion.addUser
+import io.holunda.polyflow.view.DataEntry
+import io.holunda.polyflow.view.auth.User
+import io.holunda.polyflow.view.query.data.DataEntriesForUserQuery
+import io.holunda.polyflow.view.query.data.DataEntriesQuery
+import io.holunda.polyflow.view.query.data.DataEntriesQueryResult
+import io.holunda.polyflow.view.query.data.DataEntryForIdentityQuery
+import org.assertj.core.api.Assertions.assertThat
+import org.axonframework.messaging.MetaData
+import org.axonframework.queryhandling.QueryResponseMessage
+import org.axonframework.queryhandling.SimpleQueryUpdateEmitter
+import org.camunda.bpm.engine.variable.Variables
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import java.util.*
+
+class SimpleDataEntryServiceTest {
+
+  private var service: SimpleDataEntryService = SimpleDataEntryService(queryUpdateEmitter = SimpleQueryUpdateEmitter.builder().build())
+  private val id = UUID.randomUUID().toString()
+  private val id2 = UUID.randomUUID().toString()
+  private val id3 = UUID.randomUUID().toString()
+  private val id4 = UUID.randomUUID().toString()
+  private val now = Instant.now()
+
+  @BeforeEach
+  fun `ingest events`() {
+    val payload = Variables.fromMap(mapOf("key" to "value", "key-int" to 1, "complex" to mapOf("attribute1" to "value", "attribute2" to Date.from(now))))
+
+    service.on(
+      event = DataEntryCreatedEvent(
+        entryType = "io.polyflow.test",
+        entryId = id,
+        type = "Test",
+        applicationName = "test-application",
+        name = "Test Entry 1",
+        state = ProcessingType.IN_PROGRESS.of("In progress"),
+        payload = payload,
+        authorizations = listOf(
+          addUser("kermit"),
+          addGroup("muppets")
+        ),
+        createModification = Modification(
+          time = OffsetDateTime.ofInstant(now, ZoneOffset.UTC),
+          username = "kermit",
+          log = "Created",
+          logNotes = "Created the entry"
+        )
+      ),
+      metaData = RevisionValue(revision = 1).toMetaData()
+    )
+
+    service.on(
+      event = DataEntryUpdatedEvent(
+        entryType = "io.polyflow.test",
+        entryId = id,
+        type = "Test",
+        applicationName = "test-application",
+        name = "Test Entry 1",
+        state = ProcessingType.IN_PROGRESS.of("In review"),
+        payload = payload,
+        authorizations = listOf(
+          addUser("ironman"),
+        ),
+        updateModification = Modification(
+          time = OffsetDateTime.ofInstant(now, ZoneOffset.UTC).plus(10, ChronoUnit.SECONDS),
+          username = "ironman",
+          log = "Updated",
+          logNotes = "Updated the entry"
+        )
+      ),
+      metaData = RevisionValue(revision = 2).toMetaData()
+    )
+
+    service.on(
+      event = DataEntryCreatedEvent(
+        entryType = "io.polyflow.test",
+        entryId = id2,
+        type = "Test",
+        applicationName = "test-application",
+        name = "Test Entry 2",
+        state = ProcessingType.IN_PROGRESS.of("In review"),
+        payload = Variables.putValue("key-int", 2).putValue("key", "value"),
+        authorizations = listOf(
+          addUser("piggy"),
+          addGroup("muppets")
+        ),
+        createModification = Modification(
+          time = OffsetDateTime.ofInstant(now, ZoneOffset.UTC),
+          username = "piggy",
+          log = "Created",
+          logNotes = "Created the entry"
+        )
+      ),
+      metaData = MetaData.emptyInstance()
+    )
+
+    service.on(
+      event = DataEntryCreatedEvent(
+        entryType = "io.polyflow.test",
+        entryId = id3,
+        type = "Test of deleted",
+        applicationName = "test-application",
+        name = "Test Entry 3",
+        state = ProcessingType.IN_PROGRESS.of("In review"),
+        payload = Variables.putValue("key-int", 3).putValue("key", "value"),
+        authorizations = listOf(
+          addUser("piggy"),
+          addGroup("muppets")
+        ),
+        createModification = Modification(
+          time = OffsetDateTime.ofInstant(now, ZoneOffset.UTC),
+          username = "piggy",
+          log = "Created",
+          logNotes = "Created the entry"
+        )
+      ),
+      metaData = MetaData.emptyInstance()
+    )
+
+    service.on(
+      event = DataEntryDeletedEvent(
+        entryType = "io.polyflow.test",
+        entryId = id3,
+        deleteModification = Modification(
+          time = OffsetDateTime.ofInstant(now, ZoneOffset.UTC),
+          log = "Deleted",
+          logNotes = "Created by mistake"
+        ),
+        state = ProcessingType.DELETED.of("Create error")
+      ),
+      metaData = MetaData.emptyInstance()
+    )
+
+    service.on(
+      event = DataEntryCreatedEvent(
+        entryType = "io.polyflow.test",
+        entryId = id4,
+        type = "Test sort",
+        applicationName = "test-application",
+        name = "Test Entry 4",
+        state = ProcessingType.IN_PROGRESS.of("In review"),
+        payload = Variables.putValue("key-int", 4).putValue("key", "other-value"),
+        authorizations = listOf(
+          addUser("hulk"),
+          addGroup("avenger")
+        ),
+        createModification = Modification(
+          time = OffsetDateTime.ofInstant(now, ZoneOffset.UTC),
+          username = "piggy",
+          log = "Created",
+          logNotes = "Created the entry"
+        ),
+        correlations = Variables.createVariables().addCorrelation("io.polyflow.test", id2)
+      ),
+      metaData = MetaData.emptyInstance()
+    )
+  }
+
+  @AfterEach
+  fun `cleanup projection`() {
+    listOf(id, id2, id3, id4).forEach {
+      service.on(DataEntryDeletedEvent(entryId = "io.holunda.polyflow.test", entryType = it), metaData = MetaData.emptyInstance())
+    }
+  }
+
+
+  @Test
+  fun `should find the entry by id`() {
+    val result = service.query(
+      DataEntryForIdentityQuery(entryType = "io.polyflow.test", entryId = id)
+    )
+    assertThat(result.payload).isNotNull
+    assertTestDataEntry1(result.payload)
+  }
+
+  @Test
+  fun `should find the entry by user`() {
+
+    val result = service.query(
+      DataEntriesForUserQuery(user = User("kermit", groups = setOf()))
+    )
+
+    assertResultIsTestEntry1(result)
+
+    assertResultIsTestEntry1And2(
+      service.query(
+        DataEntriesForUserQuery(user = User("superman", groups = setOf("muppets")))
+      )
+    )
+
+    assertResultIsTestEntry1(
+      service.query(
+        DataEntriesForUserQuery(user = User("ironman", groups = setOf()))
+      )
+    )
+
+    assertThat(
+      service.query(
+        DataEntriesForUserQuery(user = User("superman", groups = setOf("avengers")))
+      ).payload.elements
+    ).isEmpty()
+
+  }
+
+  @Test
+  fun `should not fail deleted already deleted entry`() {
+    service.on(
+      event = DataEntryDeletedEvent(
+        entryType = "io.polyflow.test",
+        entryId = id3,
+        deleteModification = Modification(
+          time = OffsetDateTime.ofInstant(now, ZoneOffset.UTC),
+          log = "Deleted",
+          logNotes = "Created by mistake"
+        ),
+        state = ProcessingType.DELETED.of("Create error")
+      ),
+      metaData = MetaData.emptyInstance()
+    )
+  }
+
+  @Test
+  fun `should find the entry by user and filter`() {
+    val query = DataEntriesForUserQuery(user = User("kermit", groups = setOf("muppets")), filters = listOf("key-int=1"))
+    assertResultIsTestEntry1(
+      service.query(
+        query
+      )
+    )
+  }
+
+  @Test
+  fun `should not find the deleted entry`() {
+
+    val result = service.query(
+      DataEntryForIdentityQuery(entryType = "io.polyflow.test", entryId = id3)
+    )
+    assertThat(result).isNotNull
+    assertThat(result.payload).isNull()
+  }
+
+  @Test
+  fun `should sort entries with multiple criteria`() {
+
+    val result = service.query(
+      DataEntriesQuery(sort = listOf("+type", "-name"))
+    )
+    assertThat(result.payload.elements.map { it.entryId }).containsExactlyInAnyOrder(id2, id, id4)
+  }
+
+  @Suppress("DEPRECATION")
+  @Test
+  fun `sort should be backwards compatible`() {
+
+    val result = service.query(
+      DataEntriesQuery(sort = "+type")
+    )
+    assertThat(result.payload.elements.map { it.entryId }).containsExactlyInAnyOrder(id, id2, id4)
+  }
+
+  @Test
+  fun `should not find data entry with correlations`() {
+    val result = service.query(
+      DataEntriesQuery(filters = listOf("key-int=2")) // key-int 2 is an attribute of data entry 2
+    )
+
+    assertThat(result.payload.elements.map { it.entryId }).containsExactlyInAnyOrder(id2) // id4 is not found by correlation to id2, due to property
+  }
+
+  @Test
+  fun `should find data entry by involvements`() {
+    val result = service.query(
+      DataEntriesForUserQuery(user = User("kermit", mutableSetOf("muppets")), involvementsOnly = true)
+    )
+
+    assertThat(result.payload.elements.map { it.entryId }).containsExactlyInAnyOrder(id) // user is allowed to see two dataEntries but has only one involvement
+  }
+
+  private fun assertResultIsTestEntry1(result: QueryResponseMessage<DataEntriesQueryResult>) {
+    assertThat(result.payload.elements.size).isEqualTo(1)
+    val dataEntry = result.payload.elements[0]
+    assertTestDataEntry1(dataEntry)
+  }
+
+  private fun assertResultIsTestEntry1And2(result: QueryResponseMessage<DataEntriesQueryResult>) {
+    assertThat(result.payload.elements.size).isEqualTo(2)
+    assertThat(result.payload.elements.map { it.entryId }).containsExactlyInAnyOrder(id, id2)
+    assertTestDataEntry1(result.payload.elements.first { it.entryId == id })
+    assertTestDataEntry2(result.payload.elements.first { it.entryId == id2 })
+  }
+
+
+  private fun assertTestDataEntry1(dataEntry: DataEntry) {
+    assertThat(dataEntry.entryId).isEqualTo(id)
+    assertThat(dataEntry.entryType).isEqualTo("io.polyflow.test")
+    assertThat(dataEntry.name).isEqualTo("Test Entry 1")
+    assertThat(dataEntry.payload).containsKeys("key", "key-int", "complex")
+    assertThat(dataEntry.protocol.size).isEqualTo(2)
+    assertThat(dataEntry.protocol[0].time).isEqualTo(now)
+    assertThat(dataEntry.protocol[0].username).isEqualTo("kermit")
+    assertThat(dataEntry.protocol[1].time).isEqualTo(now.plus(10, ChronoUnit.SECONDS))
+    assertThat(dataEntry.protocol[1].username).isEqualTo("ironman")
+  }
+
+  private fun assertTestDataEntry2(dataEntry: DataEntry) {
+    assertThat(dataEntry.entryId).isEqualTo(id2)
+    assertThat(dataEntry.entryType).isEqualTo("io.polyflow.test")
+    assertThat(dataEntry.name).isEqualTo("Test Entry 2")
+    assertThat(dataEntry.payload).containsKeys("key-int")
+    assertThat(dataEntry.protocol.size).isEqualTo(1)
+    assertThat(dataEntry.protocol[0].time).isEqualTo(now)
+    assertThat(dataEntry.protocol[0].username).isEqualTo("piggy")
+  }
+
+
+}

--- a/view/view-api/src/main/kotlin/query/data/DataEntriesForUserQuery.kt
+++ b/view/view-api/src/main/kotlin/query/data/DataEntriesForUserQuery.kt
@@ -11,6 +11,7 @@ import io.holunda.polyflow.view.query.PageableSortableQuery
 /**
  * Queries data entries for provided user.
  * @param user user authorized to access data entries.
+ * @param involvementsOnly controls of the result should contain only data entries where the `user` was involved
  * @param page current page, zero-based index.
  * @param size page size.
  * @param sort sort of data entries.
@@ -18,6 +19,7 @@ import io.holunda.polyflow.view.query.PageableSortableQuery
  */
 data class DataEntriesForUserQuery(
   val user: User,
+  val involvementsOnly: Boolean = false,
   override val page: Int = 0,
   override val size: Int = Int.MAX_VALUE,
   override val sort: List<String> = listOf(),
@@ -38,6 +40,15 @@ data class DataEntriesForUserQuery(
     filters = filters
   )
 
+  constructor(user: User, page: Int = 0, size: Int = Int.MAX_VALUE, sort: List<String>, filters: List<String> = listOf()): this(
+    user = user,
+    involvementsOnly = false,
+    page = page,
+    size = size,
+    sort = sort,
+    filters = filters
+  )
+
   // jackson serialization works because delegate property is private
   private val predicates by lazy { createDataEntryPredicates(toCriteria(filters)) }
 
@@ -49,4 +60,5 @@ data class DataEntriesForUserQuery(
         // authorized groups
         || (element.authorizedGroups.any { candidateGroup -> this.user.groups.contains(candidateGroup) })
       )
+      && (if (involvementsOnly) element.protocol.map { it.username }.contains(this.user.username) else true)
 }


### PR DESCRIPTION
- added a query option to only include results where a user appears in a ProtocolElement (defaults to false to keep current behavior if not specified) 
- closes #1008