### PR TITLE
Fix: Add mapping for correlations to DataEntryUpdatedEvent for JPA View

### DIFF
--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/data/ConverterExt.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/data/ConverterExt.kt
@@ -117,6 +117,7 @@ fun DataEntryUpdatedEvent.toEntity(
     formKey = this.formKey,
     authorizedPrincipals = AuthorizationChange.applyUserAuthorization(setOf(), this.authorizations).map { user(it).toString() }
       .plus(AuthorizationChange.applyGroupAuthorization(setOf(), this.authorizations).map { group(it).toString() }).toMutableSet(),
+    correlations = this.correlations.toMutableMap().map { entry -> DataEntryId(entryType = entry.key, entryId =  entry.value.toString()) }.toMutableSet(),
     revision = if (revisionValue != RevisionValue.NO_REVISION) {
       revisionValue.revision
     } else {
@@ -144,6 +145,7 @@ fun DataEntryUpdatedEvent.toEntity(
           this.authorizations
         ).map { group -> group(group).toString() })
         .toMutableSet()
+    it.correlations = this.correlations.toMutableMap().map { entry -> DataEntryId(entryType = entry.key, entryId =  entry.value.toString()) }.toMutableSet()
     it.revision = if (revisionValue != RevisionValue.NO_REVISION) {
       revisionValue.revision
     } else {

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/data/ConverterExtKtTest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/data/ConverterExtKtTest.kt
@@ -1,13 +1,17 @@
 package io.holunda.polyflow.view.jpa.data
 
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.holixon.axon.gateway.query.RevisionValue
-import io.holunda.camunda.taskpool.api.business.DataEntryAnonymizedEvent
-import io.holunda.camunda.taskpool.api.business.Modification
+import io.holunda.camunda.taskpool.api.business.*
+import io.holunda.polyflow.view.jpa.payload.PayloadAttribute
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.groups.Tuple.tuple
+import org.camunda.bpm.engine.variable.Variables
 import org.junit.jupiter.api.Test
+import java.time.Instant
 import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
 
 class ConverterExtKtTest {
     @Test
@@ -42,4 +46,149 @@ class ConverterExtKtTest {
         assertThat(anonymized.protocol).extracting(ProtocolElement::username)
             .containsExactly(tuple("ANONYMIZED"), tuple("ANONYMIZED"), tuple("SYSTEM"), tuple("SYSTEM"))
     }
+
+  @Test
+  fun shouldCreateEntity() {
+    val objectMapper = ObjectMapper()
+    val event = DataEntryCreatedEvent(
+      entryType = "io.holunda.test",
+      entryId = "id",
+      type = "type",
+      applicationName = "applicationName",
+      name = "name",
+      correlations = Variables.putValue("io.holunda.test", "id-1"),
+      payload = Variables.putValue("key", "value"),
+      description = "description",
+      state = ProcessingType.IN_PROGRESS.of("IN_CREATION"),
+      createModification = Modification(time = OffsetDateTime.now(), "Test-User", "Created Event"),
+      authorizations = listOf(AuthorizationChange.addUser("Test-User")),
+      formKey = "test-entry-form"
+    )
+
+    val entity = event.toEntity(objectMapper, RevisionValue.NO_REVISION, 2, listOf())
+
+    assertThat(entity.dataEntryId.entryId).isEqualTo("id")
+    assertThat(entity.dataEntryId.entryType).isEqualTo("io.holunda.test")
+    assertThat(entity.type).isEqualTo("type")
+    assertThat(entity.applicationName).isEqualTo("applicationName")
+    assertThat(entity.name).isEqualTo("name")
+    assertThat(entity.correlations).containsExactly(DataEntryId("id-1", "io.holunda.test"))
+    assertThat(entity.payload).isEqualTo("""{"key":"value"}""")
+    assertThat(entity.payloadAttributes).containsExactly(PayloadAttribute("key", "value"))
+    assertThat(entity.description).isEqualTo("description")
+    assertThat(entity.revision).isEqualTo(0L)
+    assertThat(entity.protocol).hasSize(1)
+    assertThat(entity.formKey).isEqualTo("test-entry-form")
+    assertThat(entity.authorizedPrincipals).containsExactly("USER:Test-User")
+    assertThat(entity.state.processingType).isEqualTo("IN_PROGRESS")
+    assertThat(entity.state.state).isEqualTo("IN_CREATION")
+  }
+
+  @Test
+  fun shouldCreateEntityIfNotPresent() {
+    val objectMapper = ObjectMapper()
+    val event = DataEntryUpdatedEvent(
+      entryType = "io.holunda.test",
+      entryId = "id",
+      type = "type",
+      applicationName = "applicationName",
+      name = "name",
+      correlations = Variables.putValue("io.holunda.test", "id-1"),
+      payload = Variables.putValue("key", "value"),
+      description = "description",
+      state = ProcessingType.IN_PROGRESS.of("IN_CREATION"),
+      updateModification = Modification(time = OffsetDateTime.now(), "Test-User", "Created Event"),
+      authorizations = listOf(AuthorizationChange.addUser("Test-User")),
+      formKey = "test-entry-form"
+    )
+
+    val entity = event.toEntity(
+      objectMapper,
+      RevisionValue.NO_REVISION,
+      null,
+      2,
+      listOf()
+    )
+
+    assertThat(entity.dataEntryId.entryId).isEqualTo("id")
+    assertThat(entity.dataEntryId.entryType).isEqualTo("io.holunda.test")
+    assertThat(entity.type).isEqualTo("type")
+    assertThat(entity.applicationName).isEqualTo("applicationName")
+    assertThat(entity.name).isEqualTo("name")
+    assertThat(entity.correlations).containsExactly(DataEntryId("id-1", "io.holunda.test"))
+    assertThat(entity.payload).isEqualTo("""{"key":"value"}""")
+    assertThat(entity.payloadAttributes).containsExactly(PayloadAttribute("key", "value"))
+    assertThat(entity.description).isEqualTo("description")
+    assertThat(entity.revision).isEqualTo(0L)
+    assertThat(entity.protocol).hasSize(1)
+    assertThat(entity.formKey).isEqualTo("test-entry-form")
+    assertThat(entity.authorizedPrincipals).containsExactly("USER:Test-User")
+    assertThat(entity.state.processingType).isEqualTo("IN_PROGRESS")
+    assertThat(entity.state.state).isEqualTo("IN_CREATION")
+  }
+
+  @Test
+  fun shouldUpdateEntity() {
+    val objectMapper = ObjectMapper()
+    val createdAt = Instant.now().minus(1, ChronoUnit.DAYS)
+    val existingEntity = DataEntryEntity(
+      dataEntryId = DataEntryId("id", "io.holunda.test"),
+      type = "type",
+      name = "name",
+      applicationName = "applicationName",
+      formKey = "test-entry-form",
+      revision = 0L,
+      state = DataEntryStateEmbeddable("IN_PROGRESS", "IN_CREATION"),
+      description = "description",
+      createdDate = createdAt,
+      lastModifiedDate = createdAt,
+      deletedDate = null,
+      authorizedPrincipals = mutableSetOf("USER:Test-User"),
+      payloadAttributes = mutableSetOf(PayloadAttribute("key", "value")),
+      protocol = mutableListOf(),
+      payload = """{"key":"value"}""",
+      correlations = mutableSetOf(DataEntryId("id-1","io.holunda.test", )),
+    )
+
+    existingEntity.protocol.add(ProtocolElement(state = DataEntryStateEmbeddable("IN_PROGRESS", "IN_CREATION"), logMessage = "Created Event", dataEntry = existingEntity, username = "Test-User"))
+
+    val event = DataEntryUpdatedEvent(
+      entryType = "io.holunda.test",
+      entryId = "id",
+      type = "type",
+      applicationName = "applicationName",
+      name = "name",
+      correlations = Variables.putValue("io.holunda.test", "id-2"),
+      payload = Variables.putValue("key", "value").putValue("key-1", "value-1"),
+      description = "description",
+      state = ProcessingType.IN_PROGRESS.of("IN_CREATION"),
+      updateModification = Modification(time = OffsetDateTime.now(), "Test-User", "Created Event"),
+      authorizations = listOf(AuthorizationChange.addGroup("Test-Group"), AuthorizationChange.addUser("Test-User-1"), AuthorizationChange.removeUser("Test-User")),
+      formKey = "test-entry-form"
+    )
+
+    val entity = event.toEntity(
+      objectMapper,
+      RevisionValue.NO_REVISION,
+      null,
+      2,
+      listOf()
+    )
+
+    assertThat(entity.dataEntryId.entryId).isEqualTo("id")
+    assertThat(entity.dataEntryId.entryType).isEqualTo("io.holunda.test")
+    assertThat(entity.type).isEqualTo("type")
+    assertThat(entity.applicationName).isEqualTo("applicationName")
+    assertThat(entity.name).isEqualTo("name")
+    assertThat(entity.correlations).containsExactlyInAnyOrder(DataEntryId("id-2", "io.holunda.test"))
+    assertThat(entity.payload).isEqualTo("""{"key-1":"value-1","key":"value"}""")
+    assertThat(entity.payloadAttributes).containsExactlyInAnyOrder(PayloadAttribute("key-1", "value-1"), PayloadAttribute("key", "value"))
+    assertThat(entity.description).isEqualTo("description")
+    assertThat(entity.revision).isEqualTo(0L)
+    assertThat(entity.protocol).hasSize(1)
+    assertThat(entity.formKey).isEqualTo("test-entry-form")
+    assertThat(entity.authorizedPrincipals).containsExactlyInAnyOrder("GROUP:Test-Group", "USER:Test-User-1")
+    assertThat(entity.state.processingType).isEqualTo("IN_PROGRESS")
+    assertThat(entity.state.state).isEqualTo("IN_CREATION")
+  }
 }


### PR DESCRIPTION
- Define correlation mapping for DataEntries in JPA
- Closes #1017