### PR TITLE
fix(#1031): Don't delete task correlations on task update events

### DIFF
--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewTaskService.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewTaskService.kt
@@ -12,14 +12,11 @@ import io.holunda.polyflow.view.jpa.auth.AuthorizationPrincipal.Companion.group
 import io.holunda.polyflow.view.jpa.auth.AuthorizationPrincipal.Companion.user
 import io.holunda.polyflow.view.jpa.data.DataEntryRepository
 import io.holunda.polyflow.view.jpa.data.toDataEntry
-import io.holunda.polyflow.view.jpa.task.TaskEntity
-import io.holunda.polyflow.view.jpa.task.TaskRepository
+import io.holunda.polyflow.view.jpa.task.*
 import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.hasApplication
 import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.isAssignedTo
 import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.isAssigneeSet
 import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.isAuthorizedFor
-import io.holunda.polyflow.view.jpa.task.toEntity
-import io.holunda.polyflow.view.jpa.task.toTask
 import io.holunda.polyflow.view.jpa.update.updateTaskQuery
 import io.holunda.polyflow.view.query.PageableSortableQuery
 import io.holunda.polyflow.view.query.task.*
@@ -387,22 +384,14 @@ class JpaPolyflowViewTaskService(
     if (isDisabledByProperty()) {
       return
     }
-
     taskRepository
       .findById(event.id)
       .ifEmpty {
         logger.warn { "Cannot update task '${event.id}' because it does not exist in the database" }
       }
       .ifPresent { entity ->
-
-        val updated = taskRepository.save(
-          event.toEntity(
-            objectMapper,
-            entity,
-            polyflowJpaViewProperties.payloadAttributeLevelLimit,
-            polyflowJpaViewProperties.taskJsonPathFilters()
-          )
-        )
+        entity.update(event, objectMapper, polyflowJpaViewProperties.payloadAttributeLevelLimit, polyflowJpaViewProperties.taskJsonPathFilters())
+        val updated = taskRepository.save(entity)
         emitTaskUpdate(updated)
       }
   }

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/task/ConverterExt.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/task/ConverterExt.kt
@@ -13,7 +13,7 @@ import io.holunda.polyflow.view.jpa.payload.PayloadAttribute
 import io.holunda.polyflow.view.jpa.process.toSourceReference
 import io.holunda.polyflow.view.jpa.process.toSourceReferenceEmbeddable
 import org.camunda.bpm.engine.variable.VariableMap
-import org.camunda.bpm.engine.variable.Variables.createVariables
+import org.camunda.bpm.engine.variable.Variables
 import java.time.Instant
 
 
@@ -46,45 +46,28 @@ fun TaskCreatedEngineEvent.toEntity(
   owner = this.owner,
 )
 
-/**
- * Update event to entity.
- */
-fun TaskAttributeUpdatedEngineEvent.toEntity(
-  objectMapper: ObjectMapper,
-  oldEntity: TaskEntity,
-  limit: Int,
-  filters: List<Pair<JsonPathFilterFunction, FilterType>>
-) = TaskEntity(
-  taskId = this.id,
-  taskDefinitionKey = this.taskDefinitionKey,
-  sourceReference = this.sourceReference.toSourceReferenceEmbeddable(),
-  authorizedPrincipals = oldEntity.authorizedPrincipals,
-  assignee = oldEntity.assignee,
-  name = this.name ?: oldEntity.name,
-  priority = this.priority ?: oldEntity.priority,
-  correlations = if (this.correlations.isNotEmpty()) {
-    this.correlations.map { entry -> DataEntryId(entryType = entry.key, entryId = "${entry.value}") }.toMutableSet()
-  } else {
-    oldEntity.correlations
-  },
-  payload = if (this.payload.isNotEmpty()) {
-    this.payload.toPayloadJson(objectMapper)
-  } else {
-    oldEntity.payload
-  },
-  payloadAttributes = if (this.payload.isNotEmpty()) {
-    this.payload.toJsonPathsWithValues(limit, filters).map { attr -> PayloadAttribute(attr) }.toMutableSet()
-  } else {
-    oldEntity.payloadAttributes
-  },
-  businessKey = this.businessKey ?: oldEntity.businessKey,
-  description = this.description ?: oldEntity.description,
-  formKey = oldEntity.formKey,
-  createdDate = oldEntity.createdDate,
-  followUpDate = this.followUpDate?.toInstant() ?: oldEntity.followUpDate,
-  dueDate = this.dueDate?.toInstant() ?: oldEntity.dueDate,
-  owner = this.owner ?: oldEntity.owner
-)
+fun TaskEntity.update(event: TaskAttributeUpdatedEngineEvent,
+                      objectMapper: ObjectMapper,
+                      limit: Int,
+                      filters: List<Pair<JsonPathFilterFunction, FilterType>>) {
+  this.taskDefinitionKey = event.taskDefinitionKey
+  this.sourceReference = event.sourceReference.toSourceReferenceEmbeddable()
+  this.name = event.name ?: this.name
+  this.priority = event.priority ?: this.priority
+  if (event.correlations.isNotEmpty()) {
+    this.correlations.clear()
+    this.correlations.addAll(event.correlations.map { entry -> DataEntryId(entryType = entry.key, entryId = "${entry.value}") }.toMutableSet())
+  }
+  if (event.payload.isNotEmpty()) {
+    this.payload = event.payload.toPayloadJson(objectMapper)
+    this.payloadAttributes =  event.payload.toJsonPathsWithValues(limit, filters).map { attr -> PayloadAttribute(attr) }.toMutableSet()
+  }
+  businessKey = event.businessKey ?: this.businessKey
+  description = event.description ?: this.description
+  followUpDate = event.followUpDate?.toInstant() ?: this.followUpDate
+  dueDate = event.dueDate?.toInstant() ?: this.dueDate
+  owner = event.owner ?: this.owner
+}
 
 /**
  * Entity to API DTO.
@@ -116,4 +99,4 @@ fun TaskEntity.toTask(
 /**
  * Create a variable map from stored data entries list.
  */
-fun MutableSet<DataEntryId>.toCorrelations(): VariableMap = createVariables().apply { this@toCorrelations.associate { it.entryType to it.entryId } }
+fun MutableSet<DataEntryId>.toCorrelations(): VariableMap = Variables.fromMap(this.associate { it.entryType to it.entryId })

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceTaskITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceTaskITest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import io.holixon.axon.gateway.query.RevisionValue
 import io.holunda.camunda.taskpool.api.business.*
 import io.holunda.camunda.taskpool.api.task.TaskAssignedEngineEvent
+import io.holunda.camunda.taskpool.api.task.TaskAttributeUpdatedEngineEvent
 import io.holunda.camunda.taskpool.api.task.TaskCompletedEngineEvent
 import io.holunda.camunda.taskpool.api.task.TaskCreatedEngineEvent
 import io.holunda.camunda.variable.serializer.serialize
@@ -15,6 +16,7 @@ import io.holunda.polyflow.view.jpa.process.toSourceReference
 import io.holunda.polyflow.view.query.data.DataEntriesForUserQuery
 import io.holunda.polyflow.view.query.task.*
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.MapEntry
 import org.axonframework.messaging.MetaData
 import org.axonframework.queryhandling.GenericSubscriptionQueryUpdateMessage
 import org.axonframework.queryhandling.QueryUpdateEmitter
@@ -221,6 +223,22 @@ internal class JpaPolyflowViewServiceTaskITest {
       ),
       metaData = RevisionValue(revision = 1).toMetaData()
     )
+
+    jpaPolyflowViewService.on(
+      event = TaskAttributeUpdatedEngineEvent(
+        id = id4,
+        taskDefinitionKey = "task.def.0815",
+        name = "task name 4",
+        priority = 10,
+        sourceReference = processReference().toSourceReference(),
+        payload = createVariables().apply { putAll(createPayload("otherValue")) },
+        correlations = newCorrelations().apply {
+          put(dataType1, dataId1)
+          put(dataType2, dataId2)
+        },
+        businessKey = "business-4",
+      ), metaData = MetaData.emptyInstance()
+    )
   }
 
   @AfterEach
@@ -255,6 +273,10 @@ internal class JpaPolyflowViewServiceTaskITest {
     assertThat(zoro.elements[0].task.name).isEqualTo("task name 4")
     assertThat(zoro.elements[0].dataEntries).isNotEmpty.hasSize(1)
     assertThat(zoro.elements[0].dataEntries[0].entryId).isEqualTo(dataId2)
+    assertThat(zoro.elements[0].task.correlations).containsOnly(
+      MapEntry.entry("io.polyflow.test1", dataId1),
+      MapEntry.entry("io.polyflow.test2", dataId2)
+    )
 
     val strawhats = jpaPolyflowViewService.query(TasksWithDataEntriesForUserQuery(user = User("other", setOf("strawhats")), assignedToMeOnly = false))
     assertThat(strawhats.elements).isNotEmpty.hasSize(2)

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/task/ConverterExtKtTest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/task/ConverterExtKtTest.kt
@@ -1,0 +1,57 @@
+package io.holunda.polyflow.view.jpa.task
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.holunda.camunda.taskpool.api.task.ProcessReference
+import io.holunda.polyflow.view.jpa.data.DataEntryId
+import io.holunda.polyflow.view.jpa.payload.PayloadAttribute
+import io.holunda.polyflow.view.jpa.process.toSourceReferenceEmbeddable
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.MapEntry
+import org.junit.jupiter.api.Test
+
+class ConverterExtKtTest {
+
+  @Test
+  fun `should convert to task`() {
+    val objectMapper = ObjectMapper()
+    val entity = TaskEntity(
+      taskId = "taskId",
+      taskDefinitionKey = "taskDefinitionKey",
+      name = "name",
+      priority = 50,
+      sourceReference = ProcessReference(
+        instanceId = "instanceId",
+        executionId = "executionId",
+        definitionId = "definitionId",
+        definitionKey = "definitionKey",
+        name = "name",
+        applicationName = "applicationName",
+      ).toSourceReferenceEmbeddable(),
+      authorizedPrincipals = mutableSetOf("GROUP:FOO", "GROUP:BAR"),
+      correlations = mutableSetOf(DataEntryId("1", "foo"), DataEntryId("2", "bar")),
+      payloadAttributes = mutableSetOf(PayloadAttribute("foo", "bar")),
+      payload = """
+        {"foo": "bar" }
+      """.trimIndent(),
+      formKey = "formKey",
+      )
+
+    val task = entity.toTask(objectMapper)
+
+    assertThat(task.id).isEqualTo("taskId")
+    assertThat(task.taskDefinitionKey).isEqualTo("taskDefinitionKey")
+    assertThat(task.name).isEqualTo("name")
+    assertThat(task.priority).isEqualTo(50)
+    assertThat(task.sourceReference.instanceId).isEqualTo("instanceId")
+    assertThat(task.sourceReference.executionId).isEqualTo("executionId")
+    assertThat(task.sourceReference.definitionId).isEqualTo("definitionId")
+    assertThat(task.sourceReference.definitionKey).isEqualTo("definitionKey")
+    assertThat(task.sourceReference.name).isEqualTo("name")
+    assertThat(task.sourceReference.applicationName).isEqualTo("applicationName")
+    assertThat(task.candidateGroups).containsExactlyInAnyOrder("FOO", "BAR")
+    assertThat(task.correlations).containsOnly(MapEntry.entry("bar", "2"), MapEntry.entry("foo", "1"))
+    assertThat(task.payload).containsOnly(MapEntry.entry("foo", "bar"))
+    assertThat(task.formKey).isEqualTo("formKey")
+
+  }
+}


### PR DESCRIPTION
Update existing entity instead of creating new one
- This avoids hibernate from merging entities
- closes #1031