### PR TITLE
#1036: Use Event timestamp instead of Changlog Date to decide if the event should be applied

### DIFF
--- a/docs/reference-guide/components/view-jpa.md
+++ b/docs/reference-guide/components/view-jpa.md
@@ -62,7 +62,7 @@ polyflow.view.jpa:
   stored-items: task, data-entry, process-instance, process-definition
   payload-attribute-level-limit: 2
   include-correlated-data-entries-in-data-entry-queries: false
-  process-old-events: false
+  process-outdated-events: false
   data-entry-filters:
     include: myProperty2.myOtherEmbeddedProperty3, myProperty2.myOtherEmbeddedProperty2
 #    exclude: myProperty
@@ -80,7 +80,7 @@ The `include-correlated-data-entries-in-data-entry-queries` flag controls whethe
 the payload of correlated data entries. The data entry attributes (such as `entry_type`, `state.state`, ...) of correlated data entries are not considered.
 *Note:* Only one level of correlation depth is considered here and there is no option yet to change the depth.
 
-With the property `process-old-events` you can configure the view such that all events are processed, even when the event timestamp is older than a different event 
+With the property `process-outdated-events` you can configure the view such that all events are processed, even when the event timestamp is older than a different event 
 that was already processed. This might be helpful when doing technical updates but should be used with care as old event will override more recent changes if the 
 order is not guaranteed. Defaults to `false`.
 

--- a/docs/reference-guide/components/view-jpa.md
+++ b/docs/reference-guide/components/view-jpa.md
@@ -62,6 +62,7 @@ polyflow.view.jpa:
   stored-items: task, data-entry, process-instance, process-definition
   payload-attribute-level-limit: 2
   include-correlated-data-entries-in-data-entry-queries: false
+  process-old-events: false
   data-entry-filters:
     include: myProperty2.myOtherEmbeddedProperty3, myProperty2.myOtherEmbeddedProperty2
 #    exclude: myProperty
@@ -78,6 +79,10 @@ storage of items not required by your application and save space consumption of 
 The `include-correlated-data-entries-in-data-entry-queries` flag controls whether a data entry query (`DataEntriesForUserQuery` or `DataEntriesQuery`) considers
 the payload of correlated data entries. The data entry attributes (such as `entry_type`, `state.state`, ...) of correlated data entries are not considered.
 *Note:* Only one level of correlation depth is considered here and there is no option yet to change the depth.
+
+With the property `process-old-events` you can configure the view such that all events are processed, even when the event timestamp is older than a different event 
+that was already processed. This might be helpful when doing technical updates but should be used with care as old event will override more recent changes if the 
+order is not guaranteed. Defaults to `false`.
 
 The attributes `data-entry-filters` and `task-filters` hold `include` / `exclude` lists of property paths which will be taken in 
 consideration during the search index creation.

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewDataEntryService.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewDataEntryService.kt
@@ -25,6 +25,7 @@ import io.holunda.polyflow.view.query.data.*
 import mu.KLogging
 import org.axonframework.config.ProcessingGroup
 import org.axonframework.eventhandling.EventHandler
+import org.axonframework.eventhandling.Timestamp
 import org.axonframework.messaging.MetaData
 import org.axonframework.queryhandling.QueryHandler
 import org.axonframework.queryhandling.QueryResponseMessage
@@ -32,6 +33,7 @@ import org.axonframework.queryhandling.QueryUpdateEmitter
 import org.springframework.data.domain.Page
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
+import java.time.Instant
 
 /**
  * Implementation of the Polyflow Data Entry View API using JPA to create the persistence model.
@@ -100,17 +102,18 @@ class JpaPolyflowViewDataEntryService(
 
   @Suppress("unused")
   @EventHandler
-  override fun on(event: DataEntryCreatedEvent, metaData: MetaData) {
+  override fun on(event: DataEntryCreatedEvent, metaData: MetaData, @Timestamp eventTimestamp: Instant) {
     if (isDisabledByProperty()) return
 
     val savedEntity = dataEntryRepository.findByIdOrNull(DataEntryId(entryType = event.entryType, entryId = event.entryId))
-    val entity = if (savedEntity == null || savedEntity.lastModifiedDate < event.createModification.time.toInstant()) {
+    val entity = if (savedEntity == null || (savedEntity.versionTimestamp < eventTimestamp.toEpochMilli() || polyflowJpaViewProperties.processOldEvents)) {
       /*
        * save the entity only if there is no newer entity in the database (possibly written by another instance of this service in HA setup)
        */
       dataEntryRepository.save(
         event.toEntity(
           objectMapper = objectMapper,
+          eventTimestamp = eventTimestamp,
           revisionValue = RevisionValue.fromMetaData(metaData),
           limit = polyflowJpaViewProperties.payloadAttributeLevelLimit,
           filters = polyflowJpaViewProperties.dataEntryJsonPathFilters()
@@ -126,17 +129,18 @@ class JpaPolyflowViewDataEntryService(
 
   @Suppress("unused")
   @EventHandler
-  override fun on(event: DataEntryUpdatedEvent, metaData: MetaData) {
+  override fun on(event: DataEntryUpdatedEvent, metaData: MetaData, @Timestamp eventTimestamp: Instant) {
     if (isDisabledByProperty()) return
 
     val savedEntity = dataEntryRepository.findByIdOrNull(DataEntryId(entryType = event.entryType, entryId = event.entryId))
-    val entity = if (savedEntity == null || savedEntity.lastModifiedDate < event.updateModification.time.toInstant()) {
+    val entity = if (savedEntity == null || (savedEntity.versionTimestamp < eventTimestamp.toEpochMilli() || polyflowJpaViewProperties.processOldEvents)) {
       /*
        * save the entity only if there is no newer entity in the database (possibly written by another instance of this service in HA setup)
        */
       dataEntryRepository.save(
         event.toEntity(
           objectMapper = objectMapper,
+          eventTimestamp = eventTimestamp,
           revisionValue = RevisionValue.fromMetaData(metaData),
           oldEntry = savedEntity,
           limit = polyflowJpaViewProperties.payloadAttributeLevelLimit,

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewDataEntryService.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewDataEntryService.kt
@@ -106,7 +106,7 @@ class JpaPolyflowViewDataEntryService(
     if (isDisabledByProperty()) return
 
     val savedEntity = dataEntryRepository.findByIdOrNull(DataEntryId(entryType = event.entryType, entryId = event.entryId))
-    val entity = if (savedEntity == null || (savedEntity.versionTimestamp < eventTimestamp.toEpochMilli() || polyflowJpaViewProperties.processOldEvents)) {
+    val entity = if (savedEntity == null || (savedEntity.versionTimestamp < eventTimestamp.toEpochMilli() || polyflowJpaViewProperties.processOutdatedEvents)) {
       /*
        * save the entity only if there is no newer entity in the database (possibly written by another instance of this service in HA setup)
        */
@@ -133,7 +133,7 @@ class JpaPolyflowViewDataEntryService(
     if (isDisabledByProperty()) return
 
     val savedEntity = dataEntryRepository.findByIdOrNull(DataEntryId(entryType = event.entryType, entryId = event.entryId))
-    val entity = if (savedEntity == null || (savedEntity.versionTimestamp < eventTimestamp.toEpochMilli() || polyflowJpaViewProperties.processOldEvents)) {
+    val entity = if (savedEntity == null || (savedEntity.versionTimestamp < eventTimestamp.toEpochMilli() || polyflowJpaViewProperties.processOutdatedEvents)) {
       /*
        * save the entity only if there is no newer entity in the database (possibly written by another instance of this service in HA setup)
        */

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/PolyflowJpaViewProperties.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/PolyflowJpaViewProperties.kt
@@ -41,7 +41,7 @@ data class PolyflowJpaViewProperties(
    * By default if an Event with a more recent timestamp was processed older events will be ignored. If this is set to "true"
    * all events will be processed. Note that this can cause issues as older events can override more recent changes. Defaults to "false"
    */
-  val processOldEvents: Boolean = false
+  val processOutdatedEvents: Boolean = false
 
 ) {
   /**

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/PolyflowJpaViewProperties.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/PolyflowJpaViewProperties.kt
@@ -35,7 +35,13 @@ data class PolyflowJpaViewProperties(
   /**
    * Controls if DataEntryQueries should consider the payload attributes of correlated data entries. Defaults to "false".
    */
-  val includeCorrelatedDataEntriesInDataEntryQueries: Boolean = false
+  val includeCorrelatedDataEntriesInDataEntryQueries: Boolean = false,
+
+  /**
+   * By default if an Event with a more recent timestamp was processed older events will be ignored. If this is set to "true"
+   * all events will be processed. Note that this can cause issues as older events can override more recent changes. Defaults to "false"
+   */
+  val processOldEvents: Boolean = false
 
 ) {
   /**

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/data/DataEntryEntity.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/data/DataEntryEntity.kt
@@ -49,6 +49,9 @@ class DataEntryEntity(
   @Column(name = "AUTHORIZED_PRINCIPAL", nullable = false)
   var authorizedPrincipals: MutableSet<String> = mutableSetOf(),
 
+  @Column(name = "VERSION_TIMESTAMP")
+  var versionTimestamp: Long = 0L,
+
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(
     name = "PLF_DATA_ENTRY_PAYLOAD_ATTRIBUTES",

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/data/DataEntryEventHandler.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/data/DataEntryEventHandler.kt
@@ -5,6 +5,7 @@ import io.holunda.camunda.taskpool.api.business.DataEntryCreatedEvent
 import io.holunda.camunda.taskpool.api.business.DataEntryDeletedEvent
 import io.holunda.camunda.taskpool.api.business.DataEntryUpdatedEvent
 import org.axonframework.messaging.MetaData
+import java.time.Instant
 
 /**
  * Interface for receiving all data entry relevant events.
@@ -14,12 +15,12 @@ interface DataEntryEventHandler {
   /**
    * Data entry created.
    */
-  fun on(event: DataEntryCreatedEvent, metaData: MetaData)
+  fun on(event: DataEntryCreatedEvent, metaData: MetaData, eventTimestamp: Instant)
 
   /**
    * Data entry updated.
    */
-  fun on(event: DataEntryUpdatedEvent, metaData: MetaData)
+  fun on(event: DataEntryUpdatedEvent, metaData: MetaData, eventTimestamp: Instant)
 
   /**
    * Data entry deleted.

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceDataEntryCorrelationITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceDataEntryCorrelationITest.kt
@@ -78,7 +78,8 @@ internal class JpaPolyflowViewServiceDataEntryCorrelationITest {
           logNotes = "Created the entry"
         )
       ),
-      metaData = MetaData.emptyInstance()
+      metaData = MetaData.emptyInstance(),
+      eventTimestamp = now
     )
 
 
@@ -103,7 +104,8 @@ internal class JpaPolyflowViewServiceDataEntryCorrelationITest {
         ),
         correlations = Variables.createVariables().addCorrelation("io.polyflow.test", id1)
       ),
-      metaData = MetaData.emptyInstance()
+      metaData = MetaData.emptyInstance(),
+      eventTimestamp = now
     )
   }
 

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceDataEntryITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceDataEntryITest.kt
@@ -127,7 +127,7 @@ internal class JpaPolyflowViewServiceDataEntryITest {
         )
       ),
       metaData = RevisionValue(revision = 2).toMetaData(),
-      now
+      now.plusSeconds(1)
     )
 
     jpaPolyflowViewService.on(
@@ -150,7 +150,7 @@ internal class JpaPolyflowViewServiceDataEntryITest {
         )
       ),
       metaData = RevisionValue(revision = 3).toMetaData(),
-      now
+      now.plusSeconds(2)
     )
 
     jpaPolyflowViewService.on(

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceTaskITest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/JpaPolyflowViewServiceTaskITest.kt
@@ -34,7 +34,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
-import org.testcontainers.junit.jupiter.Testcontainers
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
@@ -180,7 +179,8 @@ internal class JpaPolyflowViewServiceTaskITest {
           logNotes = "Created the entry"
         )
       ),
-      metaData = RevisionValue(revision = 1).toMetaData()
+      metaData = RevisionValue(revision = 1).toMetaData(),
+      now
     )
 
     // for testing: fun query(query: TasksWithDataEntriesForUserQuery)
@@ -223,7 +223,8 @@ internal class JpaPolyflowViewServiceTaskITest {
           logNotes = "Created the entry"
         )
       ),
-      metaData = RevisionValue(revision = 1).toMetaData()
+      metaData = RevisionValue(revision = 1).toMetaData(),
+      now
     )
 
     jpaPolyflowViewService.on(

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/TestFixtures.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/TestFixtures.kt
@@ -13,11 +13,13 @@ import io.holunda.polyflow.view.jpa.process.SourceReferenceEmbeddable
 import io.holunda.polyflow.view.jpa.task.TaskEntity
 import io.holunda.polyflow.view.jpa.task.TaskRepository
 import io.holunda.polyflow.view.query.data.*
+import org.axonframework.eventhandling.Timestamp
 import org.axonframework.messaging.MetaData
 import org.axonframework.queryhandling.QueryResponseMessage
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
 import java.util.*
 
 data class Pojo(
@@ -78,9 +80,9 @@ class JpaPolyflowViewServiceTxFacade(private val implementation: JpaPolyflowView
   override fun query(query: DataEntriesQuery, metaData: MetaData): QueryResponseMessage<DataEntriesQueryResult> =
     implementation.query(query = query, metaData = metaData)
 
-  override fun on(event: DataEntryCreatedEvent, metaData: MetaData) = implementation.on(event = event, metaData = metaData)
+  override fun on(event: DataEntryCreatedEvent, metaData: MetaData, @Timestamp eventTimestamp: Instant) = implementation.on(event = event, metaData = metaData, eventTimestamp)
 
-  override fun on(event: DataEntryUpdatedEvent, metaData: MetaData) = implementation.on(event = event, metaData = metaData)
+  override fun on(event: DataEntryUpdatedEvent, metaData: MetaData, @Timestamp eventTimestamp: Instant) = implementation.on(event = event, metaData = metaData, eventTimestamp)
 
   override fun on(event: DataEntryDeletedEvent, metaData: MetaData) = implementation.on(event = event, metaData = metaData)
 

--- a/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/data/ConverterExtKtTest.kt
+++ b/view/jpa/src/test/kotlin/io/holunda/polyflow/view/jpa/data/ConverterExtKtTest.kt
@@ -65,7 +65,7 @@ class ConverterExtKtTest {
       formKey = "test-entry-form"
     )
 
-    val entity = event.toEntity(objectMapper, RevisionValue.NO_REVISION, 2, listOf())
+    val entity = event.toEntity(objectMapper, Instant.now(), RevisionValue.NO_REVISION, 2, listOf())
 
     assertThat(entity.dataEntryId.entryId).isEqualTo("id")
     assertThat(entity.dataEntryId.entryType).isEqualTo("io.holunda.test")
@@ -104,6 +104,7 @@ class ConverterExtKtTest {
 
     val entity = event.toEntity(
       objectMapper,
+      Instant.now(),
       RevisionValue.NO_REVISION,
       null,
       2,
@@ -169,6 +170,7 @@ class ConverterExtKtTest {
 
     val entity = event.toEntity(
       objectMapper,
+      Instant.now(),
       RevisionValue.NO_REVISION,
       null,
       2,

--- a/view/jpa/src/test/resources/db/migrations/h2-postgresql/V0_0_7__jpa_view.sql
+++ b/view/jpa/src/test/resources/db/migrations/h2-postgresql/V0_0_7__jpa_view.sql
@@ -12,6 +12,7 @@ CREATE TABLE plf_data_entry (
   processing_type    VARCHAR(255) NOT NULL,
   state              VARCHAR(255) NOT NULL,
   type               VARCHAR(255) NOT NULL,
+  version_timestamp  INT8,
   PRIMARY KEY (entry_id, entry_type)
 );
 

--- a/view/jpa/src/test/resources/db/migrations/mariadb/V0_0_7__jpa_view.sql
+++ b/view/jpa/src/test/resources/db/migrations/mariadb/V0_0_7__jpa_view.sql
@@ -15,6 +15,7 @@ create table plf_data_entry
   processing_type    varchar(255) not null,
   state              varchar(255) not null,
   type               varchar(255) not null,
+  version_timestamp  bigint,
   primary key (entry_id, entry_type)
 );
 


### PR DESCRIPTION
- Introduced new column to store event timestamp as version Info
- Introduced configuration property to allow JPA-View to process old events even when more recent ones were already applied
- closes #1036