### PR TITLE
Add date range operator for due date and follow-up date of tasks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,15 @@
 version: 2
 updates:
-- package-ecosystem: maven
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  labels:
-  - "Type: dependencies"
-
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 19
+    labels:
+      - "Type: dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "Type: dependencies"

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
@@ -58,6 +58,6 @@ jobs:
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/docs/reference-guide/components/view-api.md
+++ b/docs/reference-guide/components/view-api.md
@@ -128,6 +128,7 @@ Following operations are supported:
 | `<`    | Less than    | all, payload | `followUpDate`, `dueDate`                                         | none                                                                     | all, payload               | all, payload                       | 
 | `>`    | Greater than | all, payload | `followUpDate`, `dueDate`                                         | none                                                                     | all, payload               | all, payload                       |
 | `=`    | Equals       | all, payload | payload, `businessKey`, `followUpDate`, `dueDate`, `priority`     | `entryId`, `entryType`, `type`, payload, `processingState`, `userStatus` | all, payload               | all, payload                       |
+| `[]`   | Between      | comparable   | `followUpDate`, `dueDate`                                         | none                                                                     | none                       | none                               |
 | `%`    | Like         | all, payload | `businessKey`, `name`, `description`, `processName`, `textSearch` | none                                                                     | none                       | none                               |
 
 !!! info

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/SpecificationExt.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/SpecificationExt.kt
@@ -20,9 +20,11 @@ import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.hasBusinessKey
 import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.hasDueDate
 import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.hasDueDateAfter
 import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.hasDueDateBefore
+import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.hasDueDateBetween
 import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.hasFollowUpDate
 import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.hasFollowUpDateAfter
 import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.hasFollowUpDateBefore
+import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.hasFollowUpDateBetween
 import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.hasPriority
 import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.hasProcessName
 import io.holunda.polyflow.view.jpa.task.TaskRepository.Companion.hasTaskOrDataEntryPayloadAttribute
@@ -266,8 +268,22 @@ internal fun Criterion.TaskCriterion.toTaskSpecification(): Specification<TaskEn
       }
     }
 
+    BETWEEN -> {
+      when (this.name) {
+        Task::dueDate.name -> hasDueDateBetween(this.value.toDatePair())
+        Task::followUpDate.name -> hasFollowUpDateBetween(this.value.toDatePair())
+        else -> throw IllegalArgumentException("JPA View found unsupported task attribute for [] (date range) comparison: ${this.name}.")
+      }
+    }
+
     else -> throw IllegalArgumentException("JPA View found unsupported comparison ${this.operator} for attribute ${this.name}.")
   }
+}
+
+private fun String.toDatePair(): Pair<Instant, Instant> {
+  val dates = this.split("|")
+  require(dates.size == 2) { "Value does not contain exactly two dates separated by |." }
+  return dates.map { Instant.parse(it) }.let { it[0] to it[1] }
 }
 
 /**

--- a/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/task/TaskRepository.kt
+++ b/view/jpa/src/main/kotlin/io/holunda/polyflow/view/jpa/task/TaskRepository.kt
@@ -131,7 +131,7 @@ interface TaskRepository : CrudRepository<TaskEntity, String>, JpaSpecificationE
     fun hasDueDateBefore(dueDate: Instant): Specification<TaskEntity> =
       Specification { task, _, builder ->
         builder.or(
-          builder.isNull(task.get<Instant>(TaskEntity::followUpDate.name)),
+          builder.isNull(task.get<Instant>(TaskEntity::dueDate.name)),
           builder.lessThan(
             task.get(TaskEntity::dueDate.name),
             dueDate
@@ -145,10 +145,31 @@ interface TaskRepository : CrudRepository<TaskEntity, String>, JpaSpecificationE
     fun hasDueDateAfter(dueDate: Instant): Specification<TaskEntity> =
       Specification { task, _, builder ->
         builder.or(
-          builder.isNull(task.get<Instant>(TaskEntity::followUpDate.name)),
+          builder.isNull(task.get<Instant>(TaskEntity::dueDate.name)),
           builder.greaterThan(
             task.get(TaskEntity::dueDate.name),
             dueDate
+          )
+        )
+      }
+
+    /**
+     * Specification for checking if the due date is in the specified range.
+     */
+    fun hasDueDateBetween(range: Pair<Instant, Instant>): Specification<TaskEntity> =
+      Specification { task, _, builder ->
+        val (from, to) = range
+        builder.or(
+          builder.isNull(task.get<Instant>(TaskEntity::dueDate.name)),
+          builder.and(
+            builder.greaterThan(
+              task.get(TaskEntity::dueDate.name),
+              from
+            ),
+            builder.lessThan(
+              task.get(TaskEntity::dueDate.name),
+              to
+            ),
           )
         )
       }
@@ -188,6 +209,27 @@ interface TaskRepository : CrudRepository<TaskEntity, String>, JpaSpecificationE
           builder.greaterThan(
             task.get(TaskEntity::followUpDate.name),
             followUpDate
+          )
+        )
+      }
+
+    /**
+     * Specification for checking if the follow-up date is in the specified range.
+     */
+    fun hasFollowUpDateBetween(range: Pair<Instant, Instant>): Specification<TaskEntity> =
+      Specification { task, _, builder ->
+        val (from, to) = range
+        builder.or(
+          builder.isNull(task.get<Instant>(TaskEntity::followUpDate.name)),
+          builder.and(
+            builder.greaterThan(
+              task.get(TaskEntity::followUpDate.name),
+              from
+            ),
+            builder.lessThan(
+              task.get(TaskEntity::followUpDate.name),
+              to
+            ),
           )
         )
       }

--- a/view/mongo/src/main/kotlin/io/holunda/polyflow/view/mongo/task/TaskWithDataEntriesRepositoryExtensionImpl.kt
+++ b/view/mongo/src/main/kotlin/io/holunda/polyflow/view/mongo/task/TaskWithDataEntriesRepositoryExtensionImpl.kt
@@ -60,6 +60,7 @@ open class TaskWithDataEntriesRepositoryExtensionImpl(
           GREATER -> this.gt(it.typedValue())
           LESS -> this.lt(it.typedValue())
           // FIXME -> implement like
+          // FIXME -> implement BETWEEN
           else -> throw IllegalArgumentException("Unsupported operator ${it.operator}")
         }
       }

--- a/view/view-api/src/main/kotlin/filter/Filter.kt
+++ b/view/view-api/src/main/kotlin/filter/Filter.kt
@@ -62,6 +62,19 @@ internal fun compareOperator(sign: String): CompareOperator =
       }
     }
 
+    BETWEEN -> { filter, actual ->
+      when(actual) {
+        is Comparable<*> -> {
+          val (from, to) = filter.toString().split("|")
+          compareOperator(GREATER)
+            .invoke(from, actual).and(compareOperator(LESS)
+              .invoke(to, actual))
+        }
+        null -> true // match tasks where actual is null
+        else -> throw IllegalArgumentException("Unsupported actual type ${actual.javaClass.name} for between operator. Type must be comparable")
+      }
+    }
+
     EQUALS -> { filter, actual -> filter.toString() == actual.toString() }
 
     else -> throw IllegalArgumentException("Unsupported operator $sign")

--- a/view/view-api/src/main/kotlin/filter/Filter.kt
+++ b/view/view-api/src/main/kotlin/filter/Filter.kt
@@ -17,6 +17,7 @@ const val EQUALS = "="
 const val LIKE = "%"
 const val GREATER = ">"
 const val LESS = "<"
+const val BETWEEN = "[]"
 const val TASK_PREFIX = "task."
 const val DATA_PREFIX = "data."
 
@@ -25,7 +26,7 @@ const val DATA_PREFIX = "data."
  */
 typealias CompareOperator = (Any, Any?) -> Boolean
 
-val OPERATORS = Regex("[$EQUALS$LESS$GREATER$LIKE]")
+val OPERATORS = listOf(EQUALS, LIKE, GREATER, LESS, BETWEEN)
 
 /**
  * Implemented comparison support for some data types.
@@ -235,7 +236,7 @@ internal fun toCriterion(filter: String): Criterion {
 
   require(filter.isNotBlank()) { "Failed to create criteria from empty filter '$filter'." }
 
-  if (!filter.contains(OPERATORS)) {
+  if (!OPERATORS.any { filter.contains(it) }) {
     return Criterion.EmptyCriterion
   }
 
@@ -244,6 +245,7 @@ internal fun toCriterion(filter: String): Criterion {
     filter.contains(LIKE) -> filter.split(LIKE).plus(LIKE)
     filter.contains(GREATER) -> filter.split(GREATER).plus(GREATER)
     filter.contains(LESS) -> filter.split(LESS).plus(LESS)
+    filter.contains(BETWEEN) -> filter.split(BETWEEN).plus(BETWEEN)
     else -> listOf()
   }.map { it.trim() }
 


### PR DESCRIPTION
A new operator was introduced to allow filtering tasks which have due dates or follow-up dates in a specific range.

`task.dueDate[]2024-10-10T08:54:56Z|2024-10-12T08:54:56Z`

The syntax used for the range operator is `[]`. To separate the dates the pipe symbol (`|`) is used.

closes #1059 